### PR TITLE
Fix typo in derivation

### DIFF
--- a/notebooks/derivation.ipynb
+++ b/notebooks/derivation.ipynb
@@ -120,7 +120,7 @@
       "\n",
       "$$I_{ikjl}^{\\infty} = \\lim_{r \\rightarrow \\infty} \\int_S\\frac{\\big (G_{ik,l}(r) + G_{il,k}(r)\\big)}{2} \\Big [C'_{ijlk}(x-r)\\bar{\\varepsilon}_{lk} + \\big [C'_{ijlk}(x-r)\\varepsilon'_{lk}(x-r)\\big ]\\Big ]n_l dS $$\n",
       "\n",
-      "$$E_{ikjl}(x) = \\Big [C'_{ijlk}(x)\\bar{\\varepsilon}_{lk} + \\big [C'_{ijlk}(x)\\varepsilon'_{lk}(x)\\big ]\\Big ]\\lim_{r \\rightarrow 0} \\int_S\\frac{\\big (G_{ik,l}(r) + G_{il,k}(r)\\big)}{2} n_l dS $$\n",
+      "$$E_{ikjl}(x) = \\lim_{r \\rightarrow 0} \\int_S\\frac{\\big (G_{ik,l}(r) + G_{il,k}(r)\\big)}{2} n_l dS $$\n",
       "\n",
       "are the contribution from the surface integrals at $\\infty$ and from the singularity.\n",
       "\n",


### PR DESCRIPTION
Fix #92

The mathematic definition of the singularity term `E` has
been corrected.
