### PR TITLE
Single phase allowed for multiphase FE

### DIFF
--- a/pymks/datasets/elastic_FE_simulation.py
+++ b/pymks/datasets/elastic_FE_simulation.py
@@ -163,10 +163,8 @@ class ElasticFESimulation(object):
         n_phases = len(self.elastic_modulus)
         if not issubclass(X.dtype.type, np.integer):
             raise TypeError("X must be an integer array")
-        if n_phases != np.max(X) + 1:
-            raise RuntimeError("X has the wrong number of phases.")
-        if np.min(X) != 0:
-            raise RuntimeError("Phases must be zero indexed.")
+        if np.max(X) >= n_phases or np.min(X) < 0:
+            raise RuntimeError("X must be between 0 and {N}.".format(N=n_phases - 1))
         if not (2 <= dim <= 3):
             raise RuntimeError("the shape of X is incorrect")
         return self._convert_properties(dim)[X]

--- a/pymks/tests/test_elastic_FE_simulation.py
+++ b/pymks/tests/test_elastic_FE_simulation.py
@@ -1,0 +1,25 @@
+
+
+def test_issue106():
+    """
+    Using a doctest to check the error strings.
+
+    >>> from pymks.datasets.elastic_FE_simulation import ElasticFESimulation
+    >>> import numpy as np
+    >>> L = 5
+    >>> elastic_modulus = (1, 2, 3)
+    >>> poissons_ratio = (0.3, 0.3, 0.3)
+    >>> size = (1, L, L)
+    >>> sim = ElasticFESimulation(elastic_modulus=elastic_modulus,
+    ...                           poissons_ratio=poissons_ratio)
+    >>> X = np.zeros(size, dtype=int)
+    >>> sim.run(X)
+    >>> X = np.ones(size, dtype=int)
+    >>> sim.run(X)
+    >>> X[0, 0, 0] = -1
+    >>> sim.run(X)
+    Traceback (most recent call last):
+    ...
+    RuntimeError: X must be between 0 and 2.
+    """
+    pass


### PR DESCRIPTION
Fix #106

Fixed bug whereby the 0 and (n_phases - 1) phases have to be present
in the X array when using ElasticFESimulation.
