### PR TITLE
Change doctests from print to assert statements

### DIFF
--- a/pymks/bases/discrete.py
+++ b/pymks/bases/discrete.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .abstract import _AbstractMicrostructureBasis    
+from .abstract import _AbstractMicrostructureBasis
 
 
 class DiscreteIndicatorBasis(_AbstractMicrostructureBasis):
@@ -15,20 +15,19 @@ class DiscreteIndicatorBasis(_AbstractMicrostructureBasis):
     (3x3) microstructre with three different phases labeled 0, 1 and
     2. The shape of `X` is `(n_samples, Nx, Ny)` where n_samples is 1
     in this case (`Nx=3` and `Ny=3`).
-    
+
     >>> basis = DiscreteIndicatorBasis(n_states=3)
     >>> X = np.array([[[1, 1, 0],
     ...                [1, 0 ,2],
     ...                [0, 1, 0]]])
-    >>> print(X.shape)
-    (1, 3, 3)
+    >>> assert(X.shape == (1, 3, 3))
 
     The `discretize` method discretizes the labeled phases into three
     different local states. This results in an array of shape
     `(n_samples, Nx, Ny, n_states)`, where `n_states=3` in this case.
     For example, if a cell has a label of 2, its local state will be
     `[0, 0, 1]`. The local state can only have values of 0 or 1.
-    
+
     >>> X_bin = np.array([[[[0, 1, 0],
     ...                     [0, 1, 0],
     ...                     [1, 0, 0]],
@@ -42,7 +41,7 @@ class DiscreteIndicatorBasis(_AbstractMicrostructureBasis):
 
     Check that the basis works when all the states are not specified
     in X.
-    
+
     >>> basis = DiscreteIndicatorBasis(n_states=3)
     >>> X = np.array([1, 1, 0])
     >>> X_bin = np.array([[0, 1, 0],
@@ -51,15 +50,16 @@ class DiscreteIndicatorBasis(_AbstractMicrostructureBasis):
     >>> assert(np.allclose(X_bin, basis.discretize(X)))
 
 
-    
+
     """
     def __init__(self, n_states=2, domain=None):
-        super(DiscreteIndicatorBasis, self).__init__(n_states, [0, n_states - 1])
-    
+        super(DiscreteIndicatorBasis, self).__init__(n_states,
+                                                     [0, n_states - 1])
+
     def discretize(self, X):
         '''
         Discretize `X`.
-        
+
         Args:
           X: Integer valued field
         Returns:

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -39,24 +39,21 @@ def crosscorrelate(X_):
     >>> n_states = 3
     >>> basis = DiscreteIndicatorBasis(n_states=n_states)
     >>> X_ = basis.discretize(X)
-    >>> print(crosscorrelate(X_).shape)
-    (1, 3, 3, 3)
+    >>> assert(crosscorrelate(X_).shape == (1, 3, 3, 3))
 
     Test for 4 states
 
     >>> n_states = 4
     >>> basis = DiscreteIndicatorBasis(n_states=n_states)
     >>> X_ = basis.discretize(X)
-    >>> print(crosscorrelate(X_).shape)
-    (1, 3, 3, 6)
+    >>> assert(crosscorrelate(X_).shape == (1, 3, 3, 6))
 
     Test for 5 states
 
     >>> n_states = 5
     >>> basis = DiscreteIndicatorBasis(n_states=n_states)
     >>> X_ = basis.discretize(X)
-    >>> print(crosscorrelate(X_).shape)
-    (1, 3, 3, 10)
+    >>> assert(crosscorrelate(X_).shape == (1, 3, 3, 10))
 
     Args:
       X: microstructure

--- a/pymks/tests/test.py
+++ b/pymks/tests/test.py
@@ -11,7 +11,9 @@ def test_elastic_FE_simulation_3D():
                                 poissons_ratio=(0., 0.))
     model.run(X)
     solution = [1., 0., 0., 0., 0., 0.]
-    assert np.allclose([np.mean(model.strain[0, ..., i]) for i in range(6)], solution)
+    assert np.allclose([np.mean(model.strain[0, ..., i]) for i in range(6)],
+                       solution)
+
 
 def test_elastic_FE_simulation_3D_BCs():
     from pymks.datasets.elastic_FE_simulation import ElasticFESimulation
@@ -19,19 +21,21 @@ def test_elastic_FE_simulation_3D_BCs():
     N = 4
     X = np.random.randint(2, size=(1, N, N, N))
     macro_strain = 0.1
-    sim = ElasticFESimulation((10.0,1.0), (0.3,0.3), macro_strain=0.1)
+    sim = ElasticFESimulation((10.0, 1.0), (0.3, 0.3), macro_strain=0.1)
     sim.run(X)
     u = sim.displacement[0]
     ## Check the left/right offset
-    assert np.allclose(u[-1,...,0] - u[0,...,0], N * macro_strain)
+    assert np.allclose(u[-1, ..., 0] - u[0, ..., 0], N * macro_strain)
     ## Check the left/right y-periodicity
-    assert np.allclose(u[0,...,1], u[-1,...,1])
-    
+    assert np.allclose(u[0, ..., 1], u[-1, ..., 1])
+
+
 def get_delta_data(nx, ny):
     from pymks.datasets import make_elastic_FE_strain_delta
-    return make_elastic_FE_strain_delta(elastic_modulus=(1, 1.1), 
-                                        poissons_ratio=(0.3, 0.3), 
+    return make_elastic_FE_strain_delta(elastic_modulus=(1, 1.1),
+                                        poissons_ratio=(0.3, 0.3),
                                         size=(nx, ny))
+
 
 def get_random_data(nx, ny):
     from pymks.datasets import make_elastic_FE_strain_random
@@ -41,8 +45,10 @@ def get_random_data(nx, ny):
                                          n_samples=1,
                                          size=(nx, ny))
 
+
 def roll_zip(*args):
     return list(zip(*tuple(np.rollaxis(x, -1) for x in args)))
+
 
 def test_MKS_elastic_delta():
     from pymks import MKSRegressionModel
@@ -54,6 +60,7 @@ def test_MKS_elastic_delta():
     model.fit(X, y_test)
     y_pred = model.predict(X)
     assert np.allclose(y_pred, y_test, rtol=1e-3, atol=1e-3)
+
 
 def test_MKS_elastic_random():
     from pymks import MKSRegressionModel
@@ -71,7 +78,7 @@ def test_MKS_elastic_random():
 def test_resize_pred():
     from pymks import MKSRegressionModel
     from pymks.bases import DiscreteIndicatorBasis
-    
+
     nx, ny = 21, 21
     resize = 3
     X_delta, y_delta = get_delta_data(nx, ny)
@@ -91,7 +98,7 @@ def test_resize_pred():
 def test_resize_coeff():
     from pymks import MKSRegressionModel
     from pymks.bases import DiscreteIndicatorBasis
-    
+
     nx, ny = 21, 21
     resize = 3
     X_delta, y_delta = get_delta_data(nx, ny)
@@ -106,12 +113,13 @@ def test_resize_coeff():
     assert np.allclose(model.coeff, big_model.coeff,
                        rtol=1e-2, atol=2.1e-3)
 
-def test_multiphase_FE_strain():        
+
+def test_multiphase_FE_strain():
     from pymks import MKSRegressionModel
     from pymks.datasets import make_elastic_FE_strain_delta
     from pymks.datasets import make_elastic_FE_strain_random
     from pymks.bases import DiscreteIndicatorBasis
-    
+
     L = 21
     i = 3
     elastic_modulus = (80, 100, 120)
@@ -119,9 +127,10 @@ def test_multiphase_FE_strain():
     macro_strain = 0.02
     size = (L, L)
 
-    X_delta, strains_delta = make_elastic_FE_strain_delta(elastic_modulus=elastic_modulus,
-                                                          poissons_ratio=poissons_ratio,
-                                                          size=size, macro_strain=macro_strain)
+    X_delta, strains_delta = \
+        make_elastic_FE_strain_delta(elastic_modulus=elastic_modulus,
+                                     poissons_ratio=poissons_ratio,
+                                     size=size, macro_strain=macro_strain)
     basis = DiscreteIndicatorBasis(len(elastic_modulus))
     MKSmodel = MKSRegressionModel(basis)
     MKSmodel.fit(X_delta, strains_delta)
@@ -136,13 +145,14 @@ def test_multiphase_FE_strain():
     assert np.allclose(strain_pred[0, i:-i], strain[0, i:-i],
                        rtol=1e-2, atol=6.1e-3)
 
+
 def test_cahn_hilliard():
     from pymks.datasets.cahn_hilliard_simulation import CahnHilliardSimulation
     from pymks.datasets import make_cahn_hilliard
     from sklearn import metrics
     from pymks import MKSRegressionModel
     from pymks import ContinuousIndicatorBasis
-    
+
     mse = metrics.mean_squared_error
     n_samples = 100
     n_spaces = 20
@@ -153,12 +163,13 @@ def test_cahn_hilliard():
     basis = ContinuousIndicatorBasis(10, [-1, 1])
     model = MKSRegressionModel(basis)
     model.fit(X, y)
-    X_test = np.array([np.random.random((n_spaces, n_spaces)) for i in range(1)])
+    X_test = np.array([np.random.random((n_spaces,
+                                         n_spaces)) for i in range(1)])
     CHSim = CahnHilliardSimulation(dt=dt)
     CHSim.run(X_test)
     y_test = CHSim.response
     y_pred = model.predict(X_test)
-    assert mse(y_test, y_pred) < 0.03
+    assert mse(y_test[0], y_pred[0]) < 0.03
 
 if __name__ == '__main__':
     test_MKS_elastic_delta()


### PR DESCRIPTION
Address issue #109

The doctest tests in stats.py and discrete.py were changed from print
statements to assert statements. In test.py that needed a simple change to the
dimensions used in the assert statement. All three files had slight style
modifications to be in line with PEP8 standards.
