### PR TITLE
Update Github link to point at openmaterials

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,7 +110,7 @@ html_theme_options = {
         ("Installation", "rst/INSTALLATION.html", True),
         ("Examples", "EXAMPLES.html", True),
         ("API", "API.html", True),
-        ("Github", "https://github.com/wd15/pymks/", True),
+        ("Github", "https://github.com/openmaterials/pymks/", True),
         ],
     'navbar_pagenav': False,
     'navbar_sidebarrel': False,


### PR DESCRIPTION
Address #94

The link was pointing at wd15, which no longer hosts the pymks site.
