### PR TITLE
Add pyfftw as fft option

### DIFF
--- a/pymks/datasets/cahn_hilliard_simulation.py
+++ b/pymks/datasets/cahn_hilliard_simulation.py
@@ -1,4 +1,10 @@
 import numpy as np
+try:
+    import pyfftw
+    np.fft = pyfftw.interfaces.numpy_fft
+    pyfftw.interfaces.cache.enable()
+except:
+    pass
 
 
 class CahnHilliardSimulation(object):
@@ -87,8 +93,8 @@ class CahnHilliardSimulation(object):
             raise RuntimeError("X must represent a square domain")
 
         L = self.dx * N
-        k = np.arange(N) 
-        
+        k = np.arange(N)
+
         if N % 2 == 0:
             N1 = N / 2
             N2 = N1

--- a/pymks/datasets/microstructure_generator.py
+++ b/pymks/datasets/microstructure_generator.py
@@ -2,6 +2,12 @@ import numpy as np
 from pymks.filter import Filter
 from scipy.ndimage.fourier import fourier_gaussian
 from .base_microstructure_generator import BaseMicrostructureGenerator
+try:
+    import pyfftw
+    np.fft = pyfftw.interfaces.numpy_fft
+    pyfftw.interfaces.cache.enable()
+except:
+    pass
 
 
 class MicrostructureGenerator(BaseMicrostructureGenerator):

--- a/pymks/filter.py
+++ b/pymks/filter.py
@@ -1,4 +1,10 @@
 import numpy as np
+try:
+    import pyfftw
+    np.fft = pyfftw.interfaces.numpy_fft
+    pyfftw.interfaces.cache.enable()
+except:
+    pass
 
 
 class Filter(object):
@@ -26,7 +32,8 @@ class Filter(object):
           an array in real space
         """
         return np.real_if_close(np.fft.fftshift(np.fft.ifftn(self.Fkernel,
-                                                             axes=self.axes), axes=self.axes))
+                                                             axes=self.axes),
+                                                axes=self.axes))
 
     def _real_2_frequency(self, kernel):
         """

--- a/pymks/mks_localization_model.py
+++ b/pymks/mks_localization_model.py
@@ -1,7 +1,12 @@
 import numpy as np
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics import r2_score
 from .filter import Filter
+try:
+    import pyfftw
+    np.fft = pyfftw.interfaces.numpy_fft
+    pyfftw.interfaces.cache.enable()
+except:
+    pass
 
 
 class MKSLocalizationModel(LinearRegression):


### PR DESCRIPTION
Address issue #162

Add pyfftw as an optional library to compute ffts. All functions will
still work if pyfftw is not install. If pyfftw is install however,
numpy.fft and ifftn will instead use pyfftw.interfaces.numpy_fft.