### PR TITLE
Change from numpy lstsq to scipy lstsq

### DIFF
--- a/pymks/datasets/__init__.py
+++ b/pymks/datasets/__init__.py
@@ -302,7 +302,7 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
     ...                      [[1, 1],
     ...                       [0, 0]]])
     >>> assert np.allclose(X, X_result)
-    >>> assert float(y[0]) == 150.
+    >>> assert np.round(y[0]).astype(int) == 150
 
     """
     if not isinstance(grain_size[0], (list, tuple, np.ndarray)):

--- a/pymks/mks_localization_model.py
+++ b/pymks/mks_localization_model.py
@@ -2,6 +2,7 @@ import numpy as np
 from sklearn.linear_model import LinearRegression
 from .filter import Filter
 from .filter import _import_pyfftw
+from scipy.linalg import lstsq
 _import_pyfftw()
 
 
@@ -117,8 +118,7 @@ class MKSLocalizationModel(LinearRegression):
         s0 = (slice(None),)
         for ijk in np.ndindex(X_.shape[1:-1]):
             s1 = self.basis._get_basis_slice(ijk, s0)
-            Fkernel[ijk + s1] = np.linalg.lstsq(FX[s0 + ijk + s1],
-                                                Fy[s0 + ijk])[0]
+            Fkernel[ijk + s1] = lstsq(FX[s0 + ijk + s1], Fy[s0 + ijk])[0]
         self._filter = Filter(Fkernel[None])
 
     @property


### PR DESCRIPTION
address issue #183

Change from numpy lstsq to scipy lstsq in order to handle array types of
complex128. This change will allow the fit method in
`MKSLocalizationModel` to work on Windows 7 and 8.