### PR TITLE
Fix to work with Sfepy 2015.2

### DIFF
--- a/pymks/datasets/elastic_FE_simulation.py
+++ b/pymks/datasets/elastic_FE_simulation.py
@@ -537,14 +537,16 @@ class ElasticFESimulation(object):
             pb.evaluate(
                 'ev_cauchy_strain.{dim}.region_all(u)'.format(
                     dim=dims),
-                mode='el_avg'))
+                mode='el_avg',
+                copy_materials=False))
         strain_reshape = np.reshape(strain, (shape + strain.shape[-1:]))
 
         stress = np.squeeze(
             pb.evaluate(
                 'ev_cauchy_stress.{dim}.region_all(m.D, u)'.format(
                     dim=dims),
-                mode='el_avg'))
+                mode='el_avg',
+                copy_materials=False))
         stress_reshape = np.reshape(stress, (shape + stress.shape[-1:]))
 
         return strain_reshape, u_reshape, stress_reshape


### PR DESCRIPTION
address #206

The latest release of SfePy (2015.2) changed the api for the evaluate
method for their Problems class. This change allows for the
latest versions of SfePy as well as previous versions to all work.