### PR TITLE
Remove save regions

### DIFF
--- a/pymks/datasets/elastic_FE_simulation.py
+++ b/pymks/datasets/elastic_FE_simulation.py
@@ -513,7 +513,6 @@ class ElasticFESimulation(object):
         ls = ScipyDirect({})
 
         pb = Problem('elasticity', equations=eqs, auto_solvers=None)
-        pb.save_regions_as_groups('regions')
 
         pb.time_update(
             ebcs=ebcs, epbcs=epbcs, lcbcs=lcbcs, functions=functions)


### PR DESCRIPTION
address #207

The elastic simulation was saving the regions.vtk file during the
the simulation. This change will no longer save the regions.vtk file
every time that the simulation simulation is run. The regions.vtk file
was unnecessary and it's absence has no side affect.