### PR TITLE
Change color dictionary and fix typo

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ for Python 2.7 (x64) and then download and install PyMKS using the [windows inst
 
 ## Installation on Mac OS X
 
-We recommend you download and install the [Anaconda Python Distibution](http://continuum.io/downloads)
+We recommend you download and install the [Anaconda Python Distribution](http://continuum.io/downloads)
 for Python 2.7 (x64). Once Anaconda has been installed, follow the above procedures to install SfePy.
 Finally, install PyMKS using `pip` as described above.
 

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -46,6 +46,7 @@ def _get_microstructure_cmap():
     Returns:
         dictionary with colors and microstructure on color bar.
     """
+
     HighRGB = np.array([229, 229, 229]) / 255.
     MediumRGB = np.array([114.5, 114.5, 114.5]) / 255.
     LowRGB = np.array([0, 0, 0]) / 255.
@@ -131,9 +132,9 @@ def _get_color_list(n_sets):
     Returns:
         list of colors for n_sets
     """
-    color_list = ['#1a9850', '#f46d43', '#762a83', '#41b6c4',
-                  '#ffff33', '#a50026', '#dd3497', '#ffffff',
-                  '#36454f', '#081d58', '#d9ef8b', '#fee08b']
+    color_list = ['#1a9850', '#f46d43', '#1f78b4', '#e31a1c',
+                  '#6a3d9a', '#b2df8a', '#fdbf6f', '#a6cee3', 
+                  '#fb9a99', '#cab2d6', '#ffff99', '#b15928']
 
     return color_list[:n_sets]
 


### PR DESCRIPTION
1. Better distinguishing data points between superimposed scatter plots.

Updates 12 colors used in scatter plots to tweaked color scheme based off of ColorBrewer's qualitative  color schemes for better visual distinction. First two colors remain the same to match branching of PyMKS logo. First five colors are dark hues, the next 5 colors are the corresponding lighter hues, and colors 11 and 12 are distinct in the case of more than 10 qualitative data sets being plotted.

An example is below.

![screen shot 2015-11-11 at 11 54 55 pm](https://cloud.githubusercontent.com/assets/5741691/11111040/4535802c-88d2-11e5-9e2e-658a761ceb1f.png)

2. Also corrects a typo in the installation instructions.