### PR TITLE
python 3 compatibility

### DIFF
--- a/pymks/datasets/__init__.py
+++ b/pymks/datasets/__init__.py
@@ -252,7 +252,7 @@ def make_checkerboard_microstructure(square_size, n_squares):
     X = np.ones((2 * square_size, 2 * square_size), dtype=int)
     X[:square_size, :square_size] = 0
     X[square_size:, square_size:] = 0
-    return np.tile(X, ((n_squares + 1) / 2, (n_squares + 1) / 2))[None, :L, :L]
+    return np.tile(X, (int((n_squares + 1) / 2), int((n_squares + 1) / 2)))[None, :L, :L]
 
 
 def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -226,7 +226,7 @@ def _auto_correlations(n_states):
     >>> l = _auto_correlations(3)
     >>> assert l == [(0, 0), (1, 1), (2, 2)]
     """
-    local_states = range(n_states)
+    local_states = list(range(int(n_states)))
     return [(l, l) for l in local_states]
 
 
@@ -242,7 +242,7 @@ def _cross_correlations(n_states):
     >>> l = _cross_correlations(3)
     >>> assert l == [(0, 1), (0, 2), (1, 2)]
     """
-    l = range(n_states)
+    l = list(range(int(n_states)))
     cross_corr = [[(l[i], l[j]) for j in l[1:][i:]] for i in l[:-1]]
     return [item for sublist in cross_corr for item in sublist]
 
@@ -327,17 +327,17 @@ def _truncate(a, shape):
 
     Example
 
-    >>> print _truncate(np.arange(10).reshape(1, 10, 1), (1, 5))[0, ..., 0]
+    >>> print(_truncate(np.arange(10).reshape(1, 10, 1), (1, 5))[0, ..., 0])
     [3 4 5 6 7]
-    >>> print _truncate(np.arange(9).reshape(1, 9, 1), (1, 5))[0, ..., 0]
+    >>> print(_truncate(np.arange(9).reshape(1, 9, 1), (1, 5))[0, ..., 0])
     [2 3 4 5 6]
-    >>> print _truncate(np.arange(10).reshape((1, 10, 1)), (1, 4))[0, ..., 0]
+    >>> print(_truncate(np.arange(10).reshape((1, 10, 1)), (1, 4))[0, ..., 0])
     [3 4 5 6]
-    >>> print _truncate(np.arange(9).reshape((1, 9, 1)), (1, 4))[0, ..., 0]
+    >>> print(_truncate(np.arange(9).reshape((1, 9, 1)), (1, 4))[0, ..., 0])
     [2 3 4 5]
 
     >>> a = np.arange(5 * 4).reshape((1, 5, 4, 1))
-    >>> print _truncate(a, shape=(1, 3, 2))[0, ..., 0]
+    >>> print(_truncate(a, shape=(1, 3, 2))[0, ..., 0])
     [[ 5  6]
      [ 9 10]
      [13 14]]

--- a/pymks/tests/test_homogenization.py
+++ b/pymks/tests/test_homogenization.py
@@ -47,8 +47,8 @@ def test_stress():
                                               macro_strain=macro_strain,
                                               seed=8)
     y_result = model.predict(X_new)
-    print np.round(y_result, decimals=2)
-    print np.round(y_new, decimals=2)
+    print(np.round(y_result, decimals=2))
+    print(np.round(y_new, decimals=2))
     assert np.allclose(np.round(y_new, decimals=2),
                        np.round(y_result, decimals=2))
 

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -256,8 +256,8 @@ def test_mask_two_samples():
                           [[0., 0., 1 / 2.],
                            [2 / 5., 3 / 5., 0.],
                            [0., 0., 2 / 3.]]]])
-    print np.round(X_corr, decimals=4)
-    print X_result
+    print(np.round(X_corr, decimals=4))
+    print(X_result)
     assert np.allclose(X_corr, X_result)
 
 

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -669,9 +669,9 @@ def _get_ticks_params(l):
     """
     segments = np.roll(np.arange(4, 7, dtype=int), 1, 0)
     m = segments[np.argmin(l % segments)]
-    n = max((l + 1) / m, 1)
-    tick_loc = range(0, l + n, n)
-    tick_labels = range(- (l - 1) / 2, (l + 1) / 2 + n, n)
+    n = int(max((l + 1) / m, 1))
+    tick_loc = list(range(0, l + n, n))
+    tick_labels = list(range(int(round(- (l - 1) / 2)), int(round(int((l + 1) / 2 + n))), n))
     return tick_loc, tick_labels
 
 


### PR DESCRIPTION
#254 

This change allows PyMKS to be compatible on Python 3.5.

It changes the way PyMKS uses print statements to work with Python 3 syntax, `range()`, and casts some function input arguments to ints.

All tests ran successfully on my machine minus the expected sfepy failures. All examples on the PyMKS website that do not use sfepy also run successfully.