### PR TITLE
Issue287 0 3 0 bugs

### DIFF
--- a/pymks/mks_homogenization_model.py
+++ b/pymks/mks_homogenization_model.py
@@ -87,7 +87,11 @@ class MKSHomogenizationModel(MKSStructureAnalysis):
             correlations (list, optional): list of spatial correlations to
                 compute, default is the autocorrelation with the first local
                 state and all of its cross correlations. For example if basis
-                has n_states=3, correlation would be [(0, 0), (0, 1), (0, 2)]
+                has basis.n_states=3, correlation would be [(0, 0), (0, 1),
+                (0, 2)]. If n_states=[0, 2, 4], the default correlations are
+                [(0, 0), (0, 2), (0, 4)] corresponding to the autocorrelations
+                for the 0th local state, and the cross correlations with the 0
+                and 2 as well as 0 and 4.
             compute_correlations (boolean, optional): If false spatial
                 correlations will not be calculated as part of the fit and
                 predict methods. The spatial correlations can be passed as `X`

--- a/pymks/mks_homogenization_model.py
+++ b/pymks/mks_homogenization_model.py
@@ -313,13 +313,7 @@ class MKSHomogenizationModel(MKSStructureAnalysis):
         """
         if not hasattr(self._linker.get_params()['connector'], "coef_"):
             raise RuntimeError('fit() method must be run before predict().')
-        _size = self.basis._axes_shape
-        if self.periodic_axes is None or len(self.periodic_axes) != len(_size):
-            _axes = range(len(_size))
-            if self.periodic_axes is not None:
-                [_axes.remove(a) for a in self.periodic_axes]
-            _size = np.ones(len(_size)) * _size
-            _size[_axes] *= .5
+        _size = self._size_axes(self.basis)
         X = self.basis._reshape_feature(X, tuple(_size))
         if self.compute_correlations is True:
             X = self._compute_stats(X, confidence_index)
@@ -347,8 +341,22 @@ class MKSHomogenizationModel(MKSStructureAnalysis):
         if not callable(getattr(self._linker, "score", None)):
             raise RuntimeError(
                 "property_linker does not have score() method.")
-        X = self.basis._reshape_feature(X, self.basis._axes_shape)
+        _size = self._size_axes(self.basis)
+        X = self.basis._reshape_feature(X, _size)
         if self.compute_correlations:
             X = self._compute_stats(X, confidence_index)
         X_reduced = self._transform(X)
         return self._linker.score(X_reduced, y)
+
+    def _size_axes(self, basis):
+        """Helper function used to get the correct size of the axes when using
+        for both periodic and non-periodic axes.
+        """
+        _size = self.basis._axes_shape
+        if self.periodic_axes is None or len(self.periodic_axes) != len(_size):
+            _axes = range(len(_size))
+            if self.periodic_axes is not None:
+                [_axes.remove(a) for a in self.periodic_axes]
+            _size = np.ones(len(_size)) * _size
+            _size[_axes] *= .5
+        return tuple(_size)

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -239,7 +239,7 @@ class MKSStructureAnalysis(BaseEstimator):
     def _fit_transform(self, X, y):
         """Reshapes X and uses it to compute the components"""
         if self.store_correlations:
-            self.fit_correlations = X
+            self.fit_correlations = X.copy()
         X_reshaped = self._reduce_shape(X)
         self.reduced_fit_data = self.dimension_reducer.fit_transform(
             X_reshaped, y)
@@ -251,9 +251,9 @@ class MKSStructureAnalysis(BaseEstimator):
         if self.store_correlations:
             if hasattr(self, 'transform_correlations'):
                 self.transform_correlations = np.concatenate(
-                    (self.transform_correlations, X))
+                    (self.transform_correlations, X.copy()))
             else:
-                self.transform_correlations = X
+                self.transform_correlations = X.copy()
 
     def _compute_stats(self, X, confidence_index):
         """

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -62,7 +62,10 @@ class MKSStructureAnalysis(BaseEstimator):
             correlations (list, optional): list of spatial correlations to
                 compute, default is the autocorrelation with the first local
                 state and all of its cross correlations. For example if basis
-                has n_states=3, correlation would be [(0, 0), (0, 1), (0, 2)]
+                has basis.n_states=3, correlation would be [(0, 0), (0, 1),
+                (0, 2)]. If n_states=[0, 2, 4], the default correlations would
+                still be [(0, 0), (0, 1), (0, 2)] corresponding to 0th, 1st
+                and 2nd states in n_states.
             periodic_axes (list, optional): axes that are periodic. (0, 2)
                 would indicate that axes x and z are periodic in a 3D
                 microstrucure.
@@ -90,7 +93,8 @@ class MKSStructureAnalysis(BaseEstimator):
             n_components = 5
         self.n_components = n_components
         if self.correlations is None and basis is not None:
-            self.correlations = [(0, l) for l in self.basis.n_states]
+            correlations = [(0, l) for l in range(len(self.basis.n_states))]
+            self.correlations = correlations
         if not callable(getattr(self.dimension_reducer,
                                 "fit_transform", None)):
             raise RuntimeError(

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -63,9 +63,10 @@ class MKSStructureAnalysis(BaseEstimator):
                 compute, default is the autocorrelation with the first local
                 state and all of its cross correlations. For example if basis
                 has basis.n_states=3, correlation would be [(0, 0), (0, 1),
-                (0, 2)]. If n_states=[0, 2, 4], the default correlations would
-                still be [(0, 0), (0, 1), (0, 2)] corresponding to 0th, 1st
-                and 2nd states in n_states.
+                (0, 2)]. If n_states=[0, 2, 4], the default correlations are
+                [(0, 0), (0, 2), (0, 4)] corresponding to the autocorrelations
+                for the 0th local state, and the cross correlations with the 0
+                and 2 as well as 0 and 4.
             periodic_axes (list, optional): axes that are periodic. (0, 2)
                 would indicate that axes x and z are periodic in a 3D
                 microstrucure.

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -299,5 +299,6 @@ class MKSStructureAnalysis(BaseEstimator):
         """
         X_reshaped = X_stats.reshape((X_stats.shape[0], X_stats[0].size))
         if self.mean_center:
-            X_reshaped -= np.mean(X_reshaped, axis=1)[:, None]
+            X_reshaped -= np.mean(X_reshaped,
+                                  axis=1)[:, None].astype(X_reshaped.dtype)
         return X_reshaped

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -23,7 +23,7 @@ def autocorrelate(X, basis, periodic_axes=[], n_jobs=1, confidence_index=None,
             pyfftw is install.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
-        autocorrelations (list, optional): list of spatial autocorrelatiions to
+        autocorrelations (list, optional): list of spatial autocorrelations to
             be computed corresponding to the states in basis.n_states. For
             example, if basis.n_states=[0, 2], then autocorrelations=[(0, 0),
             (2, 2)] computes the autocorrelations for the states 0 and 2. If
@@ -73,7 +73,7 @@ def crosscorrelate(X, basis, periodic_axes=None, n_jobs=1,
             pyfftw is install.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
-        crosscorrelations (list, optional): list of cross-correlatiions to
+        crosscorrelations (list, optional): list of cross-correlations to
             be computed corresponding to the states in basis.n_states. For
             example if basis.n_states=[2, 4, 6] then crosscorrelations=[(2, 4),
             (2, 6)] computes the cross-correlations with local states 2 and 4
@@ -148,7 +148,7 @@ def correlate(X, basis, periodic_axes=None, n_jobs=1,
             pyfftw is install.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
-        correlations (list, optional): list of  spatial correlatiions to
+        correlations (list, optional): list of  spatial _check_shapes to
             be computed corresponding to the states in basis.n_states. For
             example, it n_states=[0, 2, 5] [(0, 0), (2, 2), (0, 5)] computes
             the autocorrelations with local states 0 and 2 as well as the
@@ -192,7 +192,7 @@ def _compute_stats(X, basis, correlations, confidence_index,
             shaped array where `n_samples` is the number of samples and
             `n_x` is the spatial discretization.
         basis: an instance of a bases class
-        correlations: list of  spatial correlatiions to be computed.
+        correlations: list of  spatial correlations to be computed.
         confidence_index: array with same shape as X used to assign a
             confidence value for each data point.
         periodic_axes: axes that are periodic. (0, 2) would indicate that axes
@@ -415,6 +415,21 @@ def _mask_X_(X_, confidence_index):
 
 
 def _correlations_to_indices(correlations, basis):
-    l_0 = tuple([list(basis.n_states).index(_l[0]) for _l in correlations])
-    l_1 = tuple([list(basis.n_states).index(_l[1]) for _l in correlations])
+    """
+    Helper function to select correct indices given the local state values in
+    basis.n_states.
+
+    Args:
+        correlations: list of correlations to be computed
+        basis: an instance of a basis class.
+
+    Returns:
+        list of correlations in terms of indices
+    """
+    try:
+        l_0 = tuple([list(basis.n_states).index(_l[0]) for _l in correlations])
+        l_1 = tuple([list(basis.n_states).index(_l[1]) for _l in correlations])
+    except ValueError as ve:
+        raise ValueError('correlations value ' + ve.message[0] +
+                         ' is not in basis.n_states')
     return (l_0, l_1)

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -26,7 +26,7 @@ def autocorrelate(X, basis, periodic_axes=[], n_jobs=1, confidence_index=None,
         autocorrelations (list, optional): list of spatial autocorrelatiions to
             be computed corresponding to the states in basis.n_states. For
             example, if basis.n_states=[0, 2], then autocorrelations=[(0, 0),
-            (1, 1)] computes the autocorrelations for the states 0 and 2. If
+            (2, 2)] computes the autocorrelations for the states 0 and 2. If
             no list is passed, all autocorrelations in basis.n_states are
             computed.
 
@@ -75,8 +75,8 @@ def crosscorrelate(X, basis, periodic_axes=None, n_jobs=1,
             to assign a confidence value for each data point.
         crosscorrelations (list, optional): list of cross-correlatiions to
             be computed corresponding to the states in basis.n_states. For
-            example if basis.n_states=[2, 4, 6] then crosscorrelations=[(0, 1),
-            (0, 2)] computes the cross-correlations with local states 2 and 4
+            example if basis.n_states=[2, 4, 6] then crosscorrelations=[(2, 4),
+            (2, 6)] computes the cross-correlations with local states 2 and 4
             as well as 2 and 6. If no list is passed, all cross-correlations
             in basis.n_states are computed.
 
@@ -150,7 +150,7 @@ def correlate(X, basis, periodic_axes=None, n_jobs=1,
             to assign a confidence value for each data point.
         correlations (list, optional): list of  spatial correlatiions to
             be computed corresponding to the states in basis.n_states. For
-            example, it n_states=[0, 2, 5] [(0, 0), (1, 1), (0, 2)] computes
+            example, it n_states=[0, 2, 5] [(0, 0), (2, 2), (0, 5)] computes
             the autocorrelations with local states 0 and 2 as well as the
             cross-correlation between 0 and 5. If no list is passed, all
             spatial correlations are computed.

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -335,5 +335,24 @@ def test_autocorrelate_with_specific_correlations():
     assert np.allclose(X_auto[0, ..., 1], X_result_1)
 
 
+def test_crosscorrelate_with_specific_correlations():
+    from pymks.stats import crosscorrelate
+    from pymks import PrimitiveBasis
+    X = np.array([[[0, 0, 0, 0],
+                   [0, 1, 0, 0],
+                   [0, 0, 2, 0],
+                   [0, 0, 0, 0],
+                   [0, 0, 0, 0]]])
+    crosscorrelations = [(1, 2)]
+    p_basis = PrimitiveBasis(n_states=3)
+    X_cross = crosscorrelate(X, p_basis, crosscorrelations=crosscorrelations)
+    X_result = np.array([[0., 0., 0., 0.],
+                         [0., 0., 0., 0.],
+                         [0., 0., 0., 0.],
+                         [0., 0., 0., 1 / 12.],
+                         [0., 0., 0., 0.]])
+    assert np.allclose(X_cross[0, ..., 0], X_result)
+
+
 if __name__ == '__main__':
     test_mask_two_samples()

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -297,17 +297,45 @@ def test_stats_in_parallel():
     from pymks.bases import PrimitiveBasis
     from pymks.stats import correlate
     from pymks.datasets import make_microstructure
-    X = make_microstructure(n_samples=5, n_phases=3)
     p_basis = PrimitiveBasis(5)
-    t = []
-    for i in range(1, 4):
-        t_start = time.time()
-        correlate(X, p_basis, n_jobs=i)
-        t.append(time.time() - t_start)
     if p_basis._pyfftw:
-        assert t == sorted(t, reverse=True)
+        X = make_microstructure(n_samples=5, n_phases=3)
+        t = []
+        for i in range(1, 4):
+            t_start = time.time()
+            correlate(X, p_basis, n_jobs=i)
+            t.append(time.time() - t_start)
+            assert t == sorted(t, reverse=True)
     else:
         pass
+
+
+def test_autocorrelate_with_specific_correlations():
+    from pymks.stats import autocorrelate
+    from pymks import PrimitiveBasis
+    X = np.array([[[1, 0, 1, 1],
+                   [1, 0, 1, 1],
+                   [0, 0, 2, 0],
+                   [0, 0, 0, 0],
+                   [0, 0, 0, 0]]])
+    autocorrelations = [(0, 0), (2, 2)]
+    p_basis = PrimitiveBasis(n_states=3)
+    X_auto = autocorrelate(X, p_basis, autocorrelations=autocorrelations)
+    X_result_0 = np.array([[2 / 3., 1 / 3., 5 / 12., 4 / 9.],
+                           [5 / 8., 5 / 12., 9 / 16., 1 / 2.],
+                           [1 / 2., 7 / 15., 13 / 20., 7 / 15.],
+                           [3 / 8., 1 / 2., 9 / 16., 5 / 12.],
+                           [1 / 6., 4 / 9., 5 / 12., 1 / 3.]])
+    assert np.allclose(X_auto[0, ..., 0], X_result_0)
+    X_result_1 = np.array([[0., 0., 0., 0.],
+                           [0., 0., 0., 0.],
+                           [0., 0., 0.05, 0.],
+                           [0., 0., 0., 0.],
+                           [0., 0., 0., 0.]])
+    assert np.allclose(X_auto[0, ..., 1], X_result_1)
+
+
+
 
 if __name__ == '__main__':
     test_normalization_fftn()

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -335,7 +335,5 @@ def test_autocorrelate_with_specific_correlations():
     assert np.allclose(X_auto[0, ..., 1], X_result_1)
 
 
-
-
 if __name__ == '__main__':
-    test_normalization_fftn()
+    test_mask_two_samples()

--- a/pymks/tests/test_structure_analysis.py
+++ b/pymks/tests/test_structure_analysis.py
@@ -86,5 +86,27 @@ def test_set_components():
     model.components_ = components * 2
     assert np.allclose(model.components_, components * 2)
 
+
+def test_store_correlations():
+    from pymks import MKSStructureAnalysis
+    from pymks import PrimitiveBasis
+    from pymks.stats import correlate
+    p_basis = PrimitiveBasis(2)
+    model = MKSStructureAnalysis(basis=p_basis, store_correlations=True)
+    X = np.random.randint(2, size=(2, 4, 4))
+    model.fit(X)
+    X = correlate(X, p_basis, correlations=[(0, 0), (0, 1)])
+    assert np.allclose(X, model.fit_correlations)
+    X_0 = np.random.randint(2, size=(2, 4, 4))
+    model.transform(X_0)
+    X_corr_0 = correlate(X_0, p_basis, correlations=[(0, 0), (0, 1)])
+    assert np.allclose(X_corr_0, model.transform_correlations)
+    X_1 = np.random.randint(2, size=(2, 4, 4))
+    model.transform(X_1)
+    X_corr_1 = correlate(X_1, p_basis, correlations=[(0, 0), (0, 1)])
+    X_corr_ = np.concatenate((X_corr_0, X_corr_1))
+    assert np.allclose(X_corr_, model.transform_correlations)
+
+
 if __name__ == '__main__':
-    test_set_correlations()
+    test_store_correlations()

--- a/pymks/tests/test_structure_analysis.py
+++ b/pymks/tests/test_structure_analysis.py
@@ -70,7 +70,7 @@ def test_reshape_X():
     from pymks import MKSStructureAnalysis
     from pymks import PrimitiveBasis
     anaylzer = MKSStructureAnalysis(basis=PrimitiveBasis())
-    X = np.arange(0,18,1,dtype='float64').reshape(2, 3, 3)
+    X = np.arange(18, dtype='float64').reshape(2, 3, 3)
     X_test = np.concatenate((np.arange(-4, 5)[None], np.arange(-4, 5)[None]))
     assert np.allclose(anaylzer._reduce_shape(X), X_test)
 

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -406,7 +406,7 @@ def draw_gridscores_matrix(grid_scores, params, score_label=None,
     y_label = param_labels[1]
     plot_title = [score_label, 'Standard Deviation']
     for ax, label, matrix, title in zip(axs, param_labels,
-                                        np.swapaxes(matrices, -1, -2),
+                                        matrices,
                                         plot_title):
         ax.set_xticklabels(param_range_0, fontsize=12)
         ax.set_yticklabels(param_range_1, fontsize=12)

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -549,7 +549,7 @@ def _draw_components_2D(X, labels, title, component_labels,
     for label, pts, color in zip(labels, X, color_list):
         ax.plot(pts[:, 0], pts[:, 1], 'o', color=color, label=label)
         lg = plt.legend(loc=1, borderaxespad=0., fontsize=15)
-    if legend_outside is not None:
+    if legend_outside is not False:
         lg = plt.legend(bbox_to_anchor=(1.05, 1.0), loc=2,
                         borderaxespad=0., fontsize=15)
     lg.draggable()


### PR DESCRIPTION
This pull request fixes the following bugs:
 - the spatial correlations can now be specified when using `autocorrelate` and `crosscorrelate`
 - `MKSHomogenizationModel` works with `GridsearchCV` with non-periodic and periodic statistics
 - `draw_gridscores_matrix` now plots correctly
 - a list of local states can be passed to a basis and those same states can be passed in the `correlations` argument when computing statistics. This can be used to reduce memory usage.
 - `MKSStructureAnalysis` and `MKSHomogenizationModel` now store the correct statistics when `store_correlations` is `True`.
 - All tests now pass with numpy 1.10
