### PR TITLE
Switch to py.test and skip sfepy tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,6 @@ misc
 #Sphinx
 doc/rst
 doc/_build
+
+#pytest
+.cache

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,9 +21,12 @@ and then run the tests.
 
 ## Scipy Stack
 
-The packages [Nosetests](https://nose.readthedocs.org/en/latest/),
-[Scipy](http://www.scipy.org/), [Numpy][numpy], and
-[Scikit-learn](http://scikit-learn.org) are all required.
+Both [Scipy](http://www.scipy.org/) and [Numpy][numpy]
+[Scikit-learn](http://scikit-learn.org) are required.
+
+## Testing
+
+The package [Pytest](https://pytest.org) is required for testing only.
 
 ## Examples
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,7 +26,15 @@ Both [Scipy](http://www.scipy.org/) and [Numpy][numpy]
 
 ## Testing
 
-The package [Pytest](https://pytest.org) is required for testing only.
+The package [Pytest](https://pytest.org) is required for testing only. Use
+
+    $ py.test
+
+in the base directory or
+
+    $ python -c "import pymks; pymks.test()"
+
+to run all the tests.
 
 ## Examples
 

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -15,7 +15,7 @@ def test():
     """
     import pytest
     path = os.path.split(__file__)[0]
-    pytest.main(args=[path, '--doctest-modules'])
+    pytest.main(args=[path, '--doctest-modules', '-r s'])
 
 
 def get_version():

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -1,6 +1,4 @@
 import os
-import nose
-from nose.tools import nottest
 from .mks_localization_model import MKSLocalizationModel
 from .bases.primitive import PrimitiveBasis
 from .bases.legendre import LegendreBasis
@@ -11,13 +9,13 @@ DiscreteIndicatorBasis = PrimitiveBasis
 ContinuousIndicatorBasis = PrimitiveBasis
 
 
-@nottest
 def test():
     r"""
     Run all the doctests available.
     """
+    import pytest
     path = os.path.split(__file__)[0]
-    nose.main(argv=['-w', path, '--with-doctest'])
+    pytest.main(args=[path, '--doctest-modules'])
 
 
 def get_version():

--- a/pymks/datasets/__init__.py
+++ b/pymks/datasets/__init__.py
@@ -33,17 +33,6 @@ def make_elastic_FE_strain_delta(elastic_modulus=(100, 150),
     Returns:
         tuple containing delta microstructures and their strain fields
 
-    Example
-
-    >>> elastic_modulus = (1., 2.)
-    >>> poissons_ratio = (0.3, 0.3)
-    >>> X, y = make_elastic_FE_strain_delta(elastic_modulus=elastic_modulus,
-    ...                                     poissons_ratio=poissons_ratio,
-    ...                                     size=(5, 5))
-
-    `X` is the delta microstructures, and `y` is the
-    strain response fields.
-
     """
     from .elastic_FE_simulation import ElasticFESimulation
 
@@ -125,18 +114,6 @@ def make_elastic_FE_strain_random(n_samples=1, elastic_modulus=(100, 150),
 
     Returns:
          tuple containing delta microstructures and their strain fields
-
-    Example
-
-    >>> elastic_modulus = (1., 2.)
-    >>> poissons_ratio = (0.3, 0.3)
-    >>> X, y = make_elastic_FE_strain_random(n_samples=1,
-    ...                                      elastic_modulus=elastic_modulus,
-    ...                                      poissons_ratio=poissons_ratio,
-    ...                                      size=(5, 5))
-
-    `X` is the delta microstructures, and `y` is the
-    strain response fields.
 
     """
     from .elastic_FE_simulation import ElasticFESimulation
@@ -297,31 +274,6 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
     Returns:
         array of microstructures with dimensions (n_samples, n_x, ...) and
         effective stress values
-
-    Example
-
-    >>> X, y = make_elastic_stress_random(n_samples=1, elastic_modulus=(1, 1),
-    ...                                   poissons_ratio=(1, 1),
-    ...                                   grain_size=(3, 3), macro_strain=1.0)
-    >>> assert np.allclose(y, np.ones(y.shape))
-    >>> X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1),
-    ...                                   elastic_modulus=(100, 200),
-    ...                                   size=(2, 2), poissons_ratio=(1, 3),
-    ...                                   macro_strain=1., seed=3)
-    >>> X_result = np.array([[[1, 1],
-    ...                       [0, 1]]])
-    >>> assert np.allclose(X, X_result)
-    >>> assert float(np.round(y, decimals=5)[0]) == 228.74696
-    >>> X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1, 1),
-    ...                                   elastic_modulus=(100, 200),
-    ...                                   poissons_ratio=(1, 3),  seed=3,
-    ...                                   macro_strain=1., size=(2, 2, 2))
-    >>> X_result = np.array([[[1, 1],
-    ...                       [0, 0]],
-    ...                      [[1, 1],
-    ...                       [0, 0]]])
-    >>> assert np.allclose(X, X_result)
-    >>> assert np.round(y[0]).astype(int) == 150
 
     """
     if not isinstance(grain_size[0], (list, tuple, np.ndarray)):

--- a/pymks/datasets/elastic_FE_simulation.py
+++ b/pymks/datasets/elastic_FE_simulation.py
@@ -1,3 +1,10 @@
+try:
+    import sfepy
+except ImportError:
+    import pytest
+    pytest.importorskip('sfepy')
+    raise
+
 import numpy as np
 from sfepy.base.goptions import goptions
 from sfepy.discrete.fem import Field

--- a/pymks/tests/test_datasets.py
+++ b/pymks/tests/test_datasets.py
@@ -1,0 +1,46 @@
+from pymks.datasets import make_elastic_FE_strain_random
+from pymks.datasets import make_elastic_FE_strain_delta
+from pymks.datasets import make_elastic_stress_random
+import numpy as np
+
+
+def test_make_elastic_FE_strain_delta():
+    elastic_modulus = (1., 2.)
+    poissons_ratio = (0.3, 0.3)
+    X, y = make_elastic_FE_strain_delta(elastic_modulus=elastic_modulus,
+                                        poissons_ratio=poissons_ratio,
+                                        size=(5, 5))
+
+
+def test_make_elastic_FE_strain_random():
+    elastic_modulus = (1., 2.)
+    poissons_ratio = (0.3, 0.3)
+    X, y = make_elastic_FE_strain_random(n_samples=1,
+                                         elastic_modulus=elastic_modulus,
+                                         poissons_ratio=poissons_ratio,
+                                         size=(5, 5))
+
+
+def test_make_elastic_stress_randome():
+    X, y = make_elastic_stress_random(n_samples=1, elastic_modulus=(1, 1),
+                                      poissons_ratio=(1, 1),
+                                      grain_size=(3, 3), macro_strain=1.0)
+    assert np.allclose(y, np.ones(y.shape))
+    X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1),
+                                      elastic_modulus=(100, 200),
+                                      size=(2, 2), poissons_ratio=(1, 3),
+                                      macro_strain=1., seed=3)
+    X_result = np.array([[[1, 1],
+                          [0, 1]]])
+    assert np.allclose(X, X_result)
+    assert float(np.round(y, decimals=5)[0]) == 228.74696
+    X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1, 1),
+                                      elastic_modulus=(100, 200),
+                                      poissons_ratio=(1, 3),  seed=3,
+                                      macro_strain=1., size=(2, 2, 2))
+    X_result = np.array([[[1, 1],
+                          [0, 0]],
+                         [[1, 1],
+                          [0, 0]]])
+    assert np.allclose(X, X_result)
+    assert np.round(y[0]).astype(int) == 150

--- a/pymks/tests/test_elastic_FE_simulation.py
+++ b/pymks/tests/test_elastic_FE_simulation.py
@@ -1,25 +1,20 @@
-
+import pytest
 
 def test_issue106():
-    """
-    Using a doctest to check the error strings.
+    from pymks.datasets.elastic_FE_simulation import ElasticFESimulation
+    import numpy as np
+    L = 5
+    elastic_modulus = (1, 2, 3)
+    poissons_ratio = (0.3, 0.3, 0.3)
+    size = (1, L, L)
+    sim = ElasticFESimulation(elastic_modulus=elastic_modulus,
+                              poissons_ratio=poissons_ratio)
+    X = np.zeros(size, dtype=int)
+    sim.run(X)
+    X = np.ones(size, dtype=int)
+    sim.run(X)
+    X[0, 0, 0] = -1
 
-    >>> from pymks.datasets.elastic_FE_simulation import ElasticFESimulation
-    >>> import numpy as np
-    >>> L = 5
-    >>> elastic_modulus = (1, 2, 3)
-    >>> poissons_ratio = (0.3, 0.3, 0.3)
-    >>> size = (1, L, L)
-    >>> sim = ElasticFESimulation(elastic_modulus=elastic_modulus,
-    ...                           poissons_ratio=poissons_ratio)
-    >>> X = np.zeros(size, dtype=int)
-    >>> sim.run(X)
-    >>> X = np.ones(size, dtype=int)
-    >>> sim.run(X)
-    >>> X[0, 0, 0] = -1
-    >>> sim.run(X)
-    Traceback (most recent call last):
-    ...
-    RuntimeError: X must be between 0 and 2.
-    """
-    pass
+    with pytest.raises(RuntimeError) as excinfo:
+        sim.run(X)
+    assert "X must be between 0 and 2." == str(excinfo.value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
 description-file = README.md
 [pytest]
-addopts = --doctest-modules --ignore=setup.py
+addopts = --doctest-modules --ignore=setup.py -r s
 testpaths = pymks

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
-[nosetests]
-with-doctest = true
 [metadata]
 description-file = README.md
+[pytest]
+addopts = --doctest-modules --ignore=setup.py
+testpaths = pymks


### PR DESCRIPTION
Address #233

Switch to py.test as it allows an easy path to skip sfepy tests in the
event that the package is not installed. There is no easy way to skip
doctests that are dependent on sfepy other than having py.test skip an
entire module, thus, some tests have been removed from doctest and
made into standard `test_` functions.