### PR TITLE
Issue304 pyfftw import order

### DIFF
--- a/pymks/bases/fourier.py
+++ b/pymks/bases/fourier.py
@@ -1,5 +1,5 @@
-import numpy as np
 from .imag_ffts import _ImagFFTBasis
+import numpy as np
 
 
 class FourierBasis(_ImagFFTBasis):

--- a/pymks/bases/gsh.py
+++ b/pymks/bases/gsh.py
@@ -1,4 +1,3 @@
-import numpy as np
 from .gsh_functions import hex_eval
 from .gsh_functions import cub_eval
 from .gsh_functions import tri_eval
@@ -6,6 +5,7 @@ from .gsh_functions import hex_basis_info
 from .gsh_functions import cub_basis_info
 from .gsh_functions import tri_basis_info
 from .imag_ffts import _ImagFFTBasis
+import numpy as np
 
 
 class GSHBasis(_ImagFFTBasis):

--- a/pymks/bases/imag_ffts.py
+++ b/pymks/bases/imag_ffts.py
@@ -1,9 +1,9 @@
 from .abstract import _AbstractMicrostructureBasis
-import numpy as np
 try:
     import pyfftw.builders as fftmodule
 except:
     import numpy.fft as fftmodule
+import numpy as np
 
 
 class _ImagFFTBasis(_AbstractMicrostructureBasis):

--- a/pymks/bases/legendre.py
+++ b/pymks/bases/legendre.py
@@ -1,5 +1,5 @@
-import numpy as np
 from .real_ffts import _RealFFTBasis
+import numpy as np
 
 
 class LegendreBasis(_RealFFTBasis):

--- a/pymks/bases/primitive.py
+++ b/pymks/bases/primitive.py
@@ -1,5 +1,5 @@
-import numpy as np
 from .real_ffts import _RealFFTBasis
+import numpy as np
 
 
 class PrimitiveBasis(_RealFFTBasis):

--- a/pymks/bases/real_ffts.py
+++ b/pymks/bases/real_ffts.py
@@ -1,9 +1,9 @@
 from .abstract import _AbstractMicrostructureBasis
-import numpy as np
 try:
     import pyfftw.builders as fftmodule
 except:
     import numpy.fft as fftmodule
+import numpy as np
 
 
 class _RealFFTBasis(_AbstractMicrostructureBasis):

--- a/pymks/datasets/base_microstructure_generator.py
+++ b/pymks/datasets/base_microstructure_generator.py
@@ -1,6 +1,5 @@
-import numpy as np
 from ..bases.imag_ffts import _ImagFFTBasis
-# from ..bases.real_ffts import _RealFFTBasis
+import numpy as np
 
 
 class _BaseMicrostructureGenerator(_ImagFFTBasis):

--- a/pymks/datasets/cahn_hilliard_simulation.py
+++ b/pymks/datasets/cahn_hilliard_simulation.py
@@ -1,5 +1,5 @@
-import numpy as np
 from ..bases.imag_ffts import _ImagFFTBasis
+import numpy as np
 
 
 class CahnHilliardSimulation(_ImagFFTBasis):

--- a/pymks/datasets/microstructure_generator.py
+++ b/pymks/datasets/microstructure_generator.py
@@ -12,13 +12,14 @@ class MicrostructureGenerator(_BaseMicrostructureGenerator):
     shape of the grains.
 
     >>> n_samples, n_phases = 1, 2
-    >>> size = (3, 3)
+    >>> size = (4, 4)
     >>> generator = MicrostructureGenerator(n_samples, size,
     ...                                      n_phases, seed=10)
     >>> X = generator.generate()
-    >>> X_test = np.array([[[1, 0, 1],
-    ...                     [1, 1, 0],
-    ...                     [0, 1, 0]]])
+    >>> X_test = np.array([[[1, 0, 1, 1],
+    ...                     [1, 0, 0, 1],
+    ...                     [0, 0, 1, 1],
+    ...                     [0, 1, 1, 1]]])
     >>> assert(np.allclose(X, X_test))
 
     """
@@ -36,7 +37,8 @@ class MicrostructureGenerator(_BaseMicrostructureGenerator):
                                " not equal.")
 
         X = np.random.random((self.n_samples,) + self.size)
-        gaussian = fourier_gaussian(np.ones(self.grain_size),
+        _gaussian_size = np.around(self.grain_size).astype(int)
+        gaussian = fourier_gaussian(np.ones(_gaussian_size),
                                     np.ones(len(self.size)))
         filter_ = Filter(self._fftn(gaussian[None, ..., None]), self)
         filter_.resize(self.size)

--- a/pymks/datasets/microstructure_generator.py
+++ b/pymks/datasets/microstructure_generator.py
@@ -1,7 +1,7 @@
-import numpy as np
 from ..filter import Filter
 from scipy.ndimage.fourier import fourier_gaussian
 from .base_microstructure_generator import _BaseMicrostructureGenerator
+import numpy as np
 
 
 class MicrostructureGenerator(_BaseMicrostructureGenerator):

--- a/pymks/datasets/spherical_microstructure_generator.py
+++ b/pymks/datasets/spherical_microstructure_generator.py
@@ -1,5 +1,5 @@
-import numpy as np
 from .base_microstructure_generator import _BaseMicrostructureGenerator
+import numpy as np
 
 
 class SphericalMicrostructureGenerator(_BaseMicrostructureGenerator):

--- a/pymks/filter.py
+++ b/pymks/filter.py
@@ -1,3 +1,7 @@
+try:
+    import pyfftw
+except:
+    pass
 import numpy as np
 
 

--- a/pymks/mks_localization_model.py
+++ b/pymks/mks_localization_model.py
@@ -1,7 +1,7 @@
-import numpy as np
 from .filter import Filter
 from scipy.linalg import lstsq
 from sklearn.linear_model import LinearRegression
+import numpy as np
 
 
 class MKSLocalizationModel(LinearRegression):

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -1,7 +1,7 @@
-import numpy as np
 from pymks.stats import correlate
 from sklearn.base import BaseEstimator
 from sklearn.decomposition import RandomizedPCA
+import numpy as np
 
 
 class MKSStructureAnalysis(BaseEstimator):

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -1,5 +1,5 @@
-import numpy as np
 from .filter import Correlation
+import numpy as np
 
 """
 The stats functions take in a microstructure function and returns its two

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -206,7 +206,7 @@ def _compute_stats(X, basis, correlations, confidence_index,
     X_ = _mask_X_(X_, confidence_index)
     basis._n_jobs = n_jobs
     _Fkernel_shape(X.shape, basis, periodic_axes)
-    _norm = _normalize(X.shape, basis, confidence_index)
+    _norm = _normalize(X_.shape, basis, confidence_index)
     return _correlate(X_, basis, correlations) / _norm
 
 
@@ -311,7 +311,7 @@ def _normalize(X_shape, basis, confidence_index):
     else:
         mask = confidence_index
         if mask is None:
-            mask = np.ones(X_shape[1:])[None]
+            mask = np.ones(X_shape[1:-1])[None]
         corr = Correlation(mask[..., None], basis)
         return _truncate(corr.convolve(mask[..., None]), X_shape)
 

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -259,7 +259,7 @@ def test_normalization_rfftn():
     X_ = np.zeros((1, Nx, Ny, 1))
     prim_basis._axes = np.arange(X_.ndim - 2) + 1
     prim_basis._axes_shape = (2 * Nx, 2 * Ny)
-    norm = _normalize(X_.shape[:-1], prim_basis, None)
+    norm = _normalize(X_.shape, prim_basis, None)
     assert norm.shape == (1, Nx, Ny, 1)
     assert np.allclose(norm[0, Nx / 2, Ny / 2, 0], 25)
 
@@ -274,7 +274,7 @@ def test_normalization_fftn():
     X_ = np.zeros((1, Nx, Ny, 1))
     f_basis._axes = np.arange(X_.ndim - 2) + 1
     f_basis._axes_shape = (2 * Nx, 2 * Ny)
-    norm = _normalize(X_.shape[:-1], f_basis, None)
+    norm = _normalize(X_.shape, f_basis, None)
     assert norm.shape == (1, Nx, Ny, 1)
     assert np.allclose(norm[0, Nx / 2, Ny / 2, 0], 25)
 
@@ -287,7 +287,7 @@ def test_gsh_basis_normalization():
     X_ = np.zeros((1, Nx, Ny, 1))
     gsh_basis._axes = np.arange(X_.ndim - 2) + 1
     gsh_basis._axes_shape = (2 * Nx, 2 * Ny)
-    norm = _normalize(X_.shape[:-1], gsh_basis, None)
+    norm = _normalize(X_.shape, gsh_basis, None)
     assert norm.shape == (1, Nx, Ny, 1)
     assert np.allclose(norm[0, Nx / 2, Ny / 2, 0], 25)
 
@@ -355,4 +355,4 @@ def test_crosscorrelate_with_specific_correlations():
 
 
 if __name__ == '__main__':
-    test_mask_two_samples()
+    test_normalization_rfftn()


### PR DESCRIPTION
This PR contains fixes the following bugs:
 - The order of imports has been changed so that `pyfftw` works properly. Unfortunately, if a user imports `numpy` before `pyfftw` then `pyfftw` still raises an error.
 - Only integer values for `shape` are passed to `np.ones` to remove warnings raised by `numpy` 1.11.0
 - Changed a `shape` argument so that 2-point statistics with `GSHBasis` now works.
