### PR TITLE
Issue310 volume fraction

### DIFF
--- a/doc/datageneration.rst
+++ b/doc/datageneration.rst
@@ -28,6 +28,10 @@ make_elastic_FE_strain_delta
 ----------------------------
 .. autofunction:: pymks.datasets.make_elastic_FE_strain_delta
 
+make_elastic_stiffness
+----------------------
+.. autofunction:: pymks.datasets.make_elastic_stiffness
+
 make_elastic_stress_random
 --------------------------
 .. autofunction:: pymks.datasets.make_elastic_stress_random

--- a/pymks/datasets/__init__.py
+++ b/pymks/datasets/__init__.py
@@ -6,7 +6,7 @@ import numpy as np
 __all__ = ['make_delta_microstructures', 'make_elastic_FE_strain_delta',
            'make_elastic_FE_strain_random', 'make_cahn_hilliard',
            'make_microstructure', 'make_checkerboard_microstructure',
-           'make_elastic_stress_random']
+           'make_elastic_stress_random', 'make_elastic_stiffness']
 
 
 def make_elastic_FE_strain_delta(elastic_modulus=(100, 150),
@@ -318,3 +318,50 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
     modulus = np.sum(X_ * np.array(elastic_modulus)[index], axis=-1)
     y_stress = model.predict(X) * modulus
     return X, np.average(y_stress.reshape(len(y_stress), -1), axis=1)
+
+
+def make_elastic_stiffness(n_samples=[10, 10],
+                           elastic_modulus=(100, 150),
+                           poissons_ratio=(0.3, 0.3), size=(21, 21),
+                           macro_strain=0.01,
+                           grain_size=[(3, 3), (9, 9)],
+                           seed=10, volume_fraction=None,
+                           percent_variance=None):
+    """
+    Generates microstructures and their effective stiffness values for an
+    applied macroscopic strain.
+
+    Args:
+        n_samples (int, optional): number of samples
+        elastic_modulus (tuple, optional): list of elastic moduli for the
+            different phases.
+        poissons_ratio (tuple, optional): list of poisson's ratio values for
+            the phases.
+        size (tuple, optional): size of the microstructures
+        macro_strain (tuple, optional): macroscopic strain applied to the
+            sample.
+        grain_size (tuple, optional): effective dimensions of grains
+        seed (int, optional): seed for random number generator
+        volume_fraction(tuple, optional): specify the volume fraction of
+            each phase
+        percent_variance(int, optional): Only used if volume_fraction is
+            specified. Randomly varies the volume fraction of the
+            microstructure.
+
+
+    Returns:
+        array of microstructures with dimensions (n_samples, n_x, ...) and
+        effective stiffness values
+
+    """
+    X, stresses = make_elastic_stress_random(n_samples=n_samples,
+                                             elastic_modulus=elastic_modulus,
+                                             poissons_ratio=poissons_ratio,
+                                             size=size,
+                                             macro_strain=macro_strain,
+                                             grain_size=grain_size,
+                                             seed=seed,
+                                             volume_fraction=volume_fraction,
+                                             percent_variance=percent_variance)
+
+    return X, stresses / macro_strain

--- a/pymks/datasets/__init__.py
+++ b/pymks/datasets/__init__.py
@@ -285,6 +285,7 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
     vf_0 = volume_fraction[0]
     if not isinstance(vf_0, (list, tuple, np.ndarray)) and vf_0 is not None:
         volume_fraction = (volume_fraction,)
+        np.random.seed(seed)
     if not isinstance(size, (list, tuple, np.ndarray)) or len(size) > 3:
         raise RuntimeError('size must have length of 2 or 3')
     [RuntimeError('dimensions of size and grain_size are not the same.')
@@ -294,8 +295,10 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
          for volume_frac in volume_fraction
          if len(elastic_modulus) != len(volume_frac)]
     if len(elastic_modulus) != len(poissons_ratio):
-        raise RuntimeError('length of elastic_modulus and poissons_ratio are \
-                           not the same.')
+        raise RuntimeError('length of elastic_modulus and poissons_ratio are' \
+                           'not the same.')
+    np.random.seed(seed)
+    seed = np.random.randint(100, size=(len(volume_fraction),))
     X_cal, y_cal = make_elastic_FE_strain_delta(elastic_modulus,
                                                 poissons_ratio, size,
                                                 macro_strain)
@@ -305,10 +308,10 @@ def make_elastic_stress_random(n_samples=[10, 10], elastic_modulus=(100, 150),
     model.fit(X_cal, y_cal)
     X = np.concatenate([make_microstructure(n_samples=sample, size=size,
                                             n_phases=n_states,
-                                            grain_size=gs, seed=seed,
+                                            grain_size=gs, seed=s,
                                             volume_fraction=vf,
                                             percent_variance=percent_variance)
-                        for vf, gs, sample in zip(volume_fraction,
+                        for vf, s, gs, sample in zip(volume_fraction, seed,
                                                   grain_size, n_samples)])
     X_ = basis.discretize(X)
     index = tuple([None for i in range(len(size) + 1)]) + (slice(None),)

--- a/pymks/datasets/microstructure_generator.py
+++ b/pymks/datasets/microstructure_generator.py
@@ -66,9 +66,8 @@ class MicrostructureGenerator(_BaseMicrostructureGenerator):
             seg_shape = (len(X_sort), len(v_cum))
             per_diff = (2 * np.random.random(seg_shape) -
                         1) * np.array(self.percent_variance)
-            if -np.sum(per_diff) < self.percent_variance:
-                per_diff -= np.sum(per_diff) / len(self.volume_fraction)
-            seg_ind = np.floor((v_cum + per_diff) * X_sort.shape[1])
+            seg_ind = np.floor((v_cum + per_diff) *
+                               X_sort.shape[1]).astype(int)
             seg_values = np.concatenate([x[list(i)][None]
                                          for i, x in zip(seg_ind, X_sort)])
             new_axes = [None for i in X_blur[0].shape]

--- a/pymks/tests/test_datasets.py
+++ b/pymks/tests/test_datasets.py
@@ -29,18 +29,18 @@ def test_make_elastic_stress_randome():
     X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1),
                                       elastic_modulus=(100, 200),
                                       size=(2, 2), poissons_ratio=(1, 3),
-                                      macro_strain=1., seed=3)
+                                      macro_strain=1., seed=4)
     X_result = np.array([[[1, 1],
                           [0, 1]]])
-    assert np.allclose(X, X_result)
     assert float(np.round(y, decimals=5)[0]) == 228.74696
+    assert np.allclose(X, X_result)
     X, y = make_elastic_stress_random(n_samples=1, grain_size=(1, 1, 1),
                                       elastic_modulus=(100, 200),
-                                      poissons_ratio=(1, 3),  seed=3,
+                                      poissons_ratio=(1, 3),  seed=5,
                                       macro_strain=1., size=(2, 2, 2))
     X_result = np.array([[[1, 1],
-                          [0, 0]],
+                          [1, 0]],
                          [[1, 1],
                           [0, 0]]])
     assert np.allclose(X, X_result)
-    assert np.round(y[0]).astype(int) == 150
+    assert y.astype(int) == 145

--- a/pymks/tests/test_homogenization.py
+++ b/pymks/tests/test_homogenization.py
@@ -24,7 +24,7 @@ def test_stress():
     from pymks.datasets import make_elastic_stress_random
     from pymks import MKSHomogenizationModel, DiscreteIndicatorBasis
     sample_size = 200
-    grain_size = [(7, 7), (8, 3), (3, 9), (2, 2)]
+    grain_size = [(5, 5), (6, 4), (4, 6), (2, 2)]
     n_samples = [sample_size] * len(grain_size)
     elastic_modulus = (410, 200)
     poissons_ratio = (0.28, 0.3)
@@ -43,7 +43,7 @@ def test_stress():
     X_new, y_new = make_elastic_stress_random(
         n_samples=n_samples, size=size, grain_size=grain_size,
         elastic_modulus=elastic_modulus, poissons_ratio=poissons_ratio,
-        macro_strain=macro_strain, seed=8)
+        macro_strain=macro_strain, seed=3)
     y_result = model.predict(X_new)
     assert np.allclose(np.round(y_new, decimals=2),
                        np.round(y_result, decimals=2))

--- a/pymks/tests/test_microstructure_generator.py
+++ b/pymks/tests/test_microstructure_generator.py
@@ -33,11 +33,17 @@ def test_volume_fraction():
 
 
 def test_percent_variance():
+    volume_fraction = (0.3, 0.2, 0.5)
+    percent_variance = .2
     X = make_microstructure(n_samples=1, n_phases=3,
                             volume_fraction=(0.3, 0.2, 0.5),
-                            percent_variance=.2)
-    assert np.allclose(np.sum(X == 1) / float(X.size), 0.09, atol=1e-2)
-    assert np.allclose(np.sum(X == 2) / float(X.size), 0.57, atol=1e-2)
+                            percent_variance=percent_variance)
+    vf_1 = np.sum(X == 1) / float(X.size)
+    vf_2 = np.sum(X == 2) / float(X.size)
+    assert vf_1 > volume_fraction[1] - percent_variance
+    assert vf_1 < volume_fraction[1] + percent_variance
+    assert vf_2 > volume_fraction[2] - percent_variance
+    assert vf_2 < volume_fraction[2] + percent_variance
 
 def test_3D_volume_fraction():
     X = make_microstructure(n_samples=1, n_phases=3, size=(21, 21, 21),
@@ -46,11 +52,17 @@ def test_3D_volume_fraction():
     assert np.allclose(np.sum(X == 1) / float(X.size), 0.1, rtol=1e-3)
 
 def test_3D_percent_variance():
+    volume_fraction = (0.7, 0.1, 0.2)
+    percent_variance = .2
     X = make_microstructure(n_samples=1, n_phases=3, size=(21, 21, 21),
-                            volume_fraction=(0.7, 0.1, 0.2),
-                            percent_variance=.2)
-    assert np.allclose(np.sum(X == 1) / float(X.size), 0.05, atol=1e-2)
-    assert np.allclose(np.sum(X == 2) / float(X.size), 0.2, atol=1e-2)
+                            volume_fraction=volume_fraction,
+                            percent_variance=percent_variance)
+    vf_1 = np.sum(X == 1) / float(X.size)
+    vf_2 = np.sum(X == 2) / float(X.size)
+    assert vf_1 > volume_fraction[1] - percent_variance
+    assert vf_1 < volume_fraction[1] + percent_variance
+    assert vf_2 > volume_fraction[2] - percent_variance
+    assert vf_2 < volume_fraction[2] + percent_variance
 
 if __name__ == '__main__':
     test_3D_volume_fraction()

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -14,7 +14,9 @@ import numpy as np
 import warnings
 
 warnings.filterwarnings("ignore")
-plt.style.library['ggplot']['text.color'] = '#555555'
+plt.style.library['ggplot']['xtick.color'] = '#000000'
+plt.style.library['ggplot']['ytick.color'] = '#000000'
+plt.style.library['ggplot']['axes.labelcolor'] = '#000000'
 plt.style.use('ggplot')
 
 


### PR DESCRIPTION
This PR makes the following changes. 
 * Fixes a bug with the `make_microstructure` function that caused the percent volume fraction ranges to occasionally be random. 
 * Causes the `make_elastic_stress_random` function to use a different random seed for each class of microstructure generated.
 * Introduces the `make_elastic_stiffness` function that returns microstructures and their effective stiffness
 * Changes the text color on images from gray to black to make labels and titles easier to read.
