### PR TITLE
Conda py3

### DIFF
--- a/builds/conda/pymks/README.md
+++ b/builds/conda/pymks/README.md
@@ -1,9 +1,13 @@
-Use
+# Building and uploading to Conda pymks/pymks channel
 
-    $ conda build -c wd15 .
+The user and channel is, https://anaconda.org/pymks/pymks.
 
-to build and
+Remember to change the `version` and `git_rev`.
 
-    $ anaconda upload home/wd15/anaconda/conda-bld/linux-64/pymks-0.3.1_dev.XXXX
+To build and upload use,
 
-to upload.
+    $ conda update -n root conda-build
+    $ conda clean --lock
+    $ conda clean --all
+    $ conda build --python=3.5
+    $ anaconda upload -u pymks -c pymks /home/wd15/anaconda/conda-bld/linux-64/pymks-0.3.3.dev17+g817dc61-py35_1.tar.bz2

--- a/builds/conda/pymks/README.md
+++ b/builds/conda/pymks/README.md
@@ -6,8 +6,9 @@ Remember to change the `version` and `git_rev`.
 
 To build and upload use,
 
+    $ conda install -n root conda-build
     $ conda update -n root conda-build
-    $ conda clean --lock
-    $ conda clean --all
-    $ conda build --python=3.5
-    $ anaconda upload -u pymks -c pymks /home/wd15/anaconda/conda-bld/linux-64/pymks-0.3.3.dev17+g817dc61-py35_1.tar.bz2
+    $ conda clean --lock # can help when can't build
+    $ conda clean --all # can help when can't build
+    $ conda build --python=3.5 .
+    $ anaconda upload -u pymks -c pymks /home/wd15/anaconda/conda-bld/linux-64/pymks-X.Y.Z.tar.bz2

--- a/builds/conda/pymks/build.sh
+++ b/builds/conda/pymks/build.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 
+## Following is a hack to build Sfepy as Conda build is broken
+pwd=`pwd`
+cd ..
+git clone https://github.com/sfepy/sfepy.git
+cd sfepy
+git checkout release_2016.3
+python setup.py install
+cd ${pwd}
+## End of Sfepy hack
+
 $PYTHON setup.py install

--- a/builds/conda/pymks/meta.yaml
+++ b/builds/conda/pymks/meta.yaml
@@ -1,11 +1,13 @@
----
+{% set version = "0.3.3.dev17+g817dc61" %}
+{% set name = "pymks" %}
+
 package:
-  name: pymks
-  version: "0.3.1"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  git_url: https://github.com/materialsinnovation/pymks.git
-  git_rev: a3757c72
+  git_url: https://github.com/materialsinnovation/{{ name }}.git
+  git_rev: 817dc61
 
 build:
   number: 1
@@ -14,16 +16,25 @@ requirements:
   build:
     - python
     - anaconda
-    - sfepy
     - pytest
     - scikit-learn
+    - pytest-cov
+    - pylint
+    - cython
+    - sympy
+    - pytables
 
   run:
     - python
     - anaconda
-    - sfepy
     - pytest
     - scikit-learn
+    - pytest-cov
+    - pylint
+    - cython
+    - sympy
+    - pytables
+    - pyparsing
 
 about:
-  home: http://pymks.org
+  home: http://{{ name }}.org

--- a/builds/conda/pymks/meta.yaml
+++ b/builds/conda/pymks/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - sympy
     - pytables
     - pyparsing
+    - matplotlib
 
 about:
   home: http://{{ name }}.org

--- a/builds/conda/pymks/meta.yaml
+++ b/builds/conda/pymks/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "pymks" %}
-{% set version = load_setup_py_data().version %}
+{% set version = "0.3.3.dev20+g050b7a8" %}
+{% set github_org = "wd15" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  git_url: https://github.com/materialsinnovation/{{ name }}.git
-  git_rev: 817dc61
+  git_url: https://github.com/{{ github_org }}/{{ name }}.git
+  git_rev: 050b7a8
 
 build:
   number: 1

--- a/builds/conda/pymks/meta.yaml
+++ b/builds/conda/pymks/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.3.3.dev17+g817dc61" %}
 {% set name = "pymks" %}
+{% set version = load_setup_py_data().version %}
 
 package:
   name: {{ name }}

--- a/builds/conda/sfepy/README.md
+++ b/builds/conda/sfepy/README.md
@@ -1,0 +1,11 @@
+Unable to build see issue https://github.com/materialsinnovation/pymks/issues/323.
+
+For reference, the files are stored at
+https://anaconda.org/pymks/pymks. Useful commands when building with
+conda are below. They fixed issues with the build up until the failure
+in the issue above.
+
+    $ conda update -n root conda-build
+    $ conda clean --all
+    $ conda build --python=3.5 .
+    $ anaconda upload home/wd15/anaconda/conda-bld/linux-64/sfepyXXXXX

--- a/builds/conda/sfepy/meta.yaml
+++ b/builds/conda/sfepy/meta.yaml
@@ -1,11 +1,13 @@
----
+{% set version = "2016.3" %}
+{% set name = "sfepy" %}
+
 package:
-  name: sfepy
-  version: 2016.1
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  git_url: https://github.com/sfepy/sfepy.git
-  git_rev: release_2016.1
+  git_url: https://github.com/{{ name }}/{{ name }}.git
+  git_rev: release_{{ version }}
 
 build:
   number: 1
@@ -15,11 +17,16 @@ requirements:
     - python
     - anaconda
     - cython
+    - sympy
+    - pytables
 
   run:
     - python
     - anaconda
     - pyparsing
+    - sympy
+    - cython
+    - pytables
 
 about:
-  home: http://sfepy.org
+  home: http://{{ name }}.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
 description-file = README.md
-[pytest]
+[tool:pytest]
 addopts = --doctest-modules --ignore=setup.py -r s --cov=pymks --cov-report term-missing
 testpaths = pymks


### PR DESCRIPTION
Updates the conda recipe for PyMKS to automatically install Sfepy in Python 3. Sfepy Conda installer is not working in Python 3 so the build.sh now downloads and install Sfepy. This issue will be raised with Sfepy in the process of making Sfepy available on conda-forge. When Sfepy is available on conda forge then PyMKS can be made available on conda forge.