### PR TITLE
Issue325 default fft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
       python setup.py install;
       cd $TRAVIS_BUILD_DIR;
     fi
-  - pip install pylint
+  - pip install pylint configparser
   - pip install .
 script:
   - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: python
 env:
-  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 USE_FFTW=0 PYTHON_VERSION=3
-  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 USE_FFTW=0 PYTHON_VERSION=2
-  - SFEPY_VERSION=master USE_SFEPY=1 USE_FFTW=0 PYTHON_VERSION=2
+  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 PYMKS_USE_FFTW=1 PYTHON_VERSION=3
+  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 PYMKS_USE_FFTW=0 PYTHON_VERSION=3
+  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 PYMKS_USE_FFTW=1 PYTHON_VERSION=2
+  - SFEPY_VERSION=release_2016.3 USE_SFEPY=1 PYMKS_USE_FFTW=0 PYTHON_VERSION=2
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
@@ -24,7 +25,7 @@ install:
   - source activate test-environment
   - conda install -q -y -n test-environment numpy scipy pytest scikit-learn matplotlib pytest-cov
   - conda install -q -y -n test-environment sympy cython pytables
-  - if [[ "$USE_FFTW" -eq 1 ]]; then
+  - if [[ "$PYMKS_USE_FFTW" -eq 1 ]]; then
       conda install -q -y -n test-environment -c wd15 pyfftw;
     fi
   - if [[ "$USE_SFEPY" -eq 1 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda install -q -y -n test-environment numpy scipy pytest scikit-learn matplotlib pytest-cov
   - conda install -q -y -n test-environment sympy cython pytables
   - if [[ "$PYMKS_USE_FFTW" -eq 1 ]]; then
-      conda install -q -y -n test-environment -c wd15 pyfftw;
+      conda install -q -y -n test-environment -c conda-forge pyfftw;
     fi
   - if [[ "$USE_SFEPY" -eq 1 ]]; then
       git clone https://github.com/sfepy/sfepy.git ~/sfepy;

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,7 +11,8 @@ Conda is the easiest way to install PyMKS. To install use
 
 ## Pip
 
-The following steps outline the necessary requirements for a successful installation of PyMKS.
+The following steps outline the necessary requirements for a
+successful installation of PyMKS.
 
 Use pip,
 
@@ -23,8 +24,10 @@ and then run the tests.
 
 ## Scipy Stack
 
-Both [Scipy](http://www.scipy.org/) and [Numpy][numpy]
-as well as [Scikit-learn](http://scikit-learn.org) are required.
+Both [Scipy](http://www.scipy.org/) and [Numpy][numpy] as well as
+[Scikit-learn](http://scikit-learn.org) are required. See the
+[requirements](./requirement.txt) for a full listing of PyMKS
+dependencies.
 
 ## Testing
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -86,6 +86,10 @@ To install [PyFFTW][pyfftw] use pip
 
     $ pip install pyfftw
 
+or the Conda-Forge Conda channel,
+
+    $ conda install -c conda-forge pyfftw
+
 See the
 [PyFFTW installation instructions](https://github.com/hgomersall/pyFFTW#installation)
 for more details.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -64,17 +64,28 @@ for more details.
 
 ## [PyFFTW][pyfftw]
 
-If installed, PyMKS will use [PyFFTW][pyfftw] to
-compute FFTs instead of [Numpy][numpy]. As long as [Numpy][numpy] is
-not using [Intel MKL][MKL], [PyFFTW][pyfftw] should improve the
-performance of PyMKS.
+
+PyMKS can use [PyFFTW][pyfftw] to compute FFTs instead of
+[Numpy][numpy]. As long as [Numpy][numpy] is not using
+[Intel MKL][MKL], [PyFFTW][pyfftw] should improve the performance of
+PyMKS. To use [PyFFTW][pyfftw], either set the environment variable
+
+    $ export PYMKS_USE_FFTW=1
+
+or set
+
+    [pymks]
+    use-fftw = true
+
+in `setup.cfg` before installation.
 
 To install [PyFFTW][pyfftw] use pip
 
     $ pip install pyfftw
 
-See the [PyFFTW installation instructions](https://github.com/hgomersall/pyFFTW#installation)
- for more details.
+See the
+[PyFFTW installation instructions](https://github.com/hgomersall/pyFFTW#installation)
+for more details.
 
 ## Installation on Windows
 

--- a/builds/conda/pymks/meta.yaml
+++ b/builds/conda/pymks/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cython
     - sympy
     - pytables
+    - configparser
 
   run:
     - python
@@ -37,6 +38,7 @@ requirements:
     - pytables
     - pyparsing
     - matplotlib
+    - configparser
 
 about:
   home: http://{{ name }}.org

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -1,3 +1,10 @@
+try:
+    import pyfftw
+    ## ensure that pyfftw is always imported before numpy to avoid
+    ## https://github.com/materialsinnovation/pymks/issues/304
+except ImportError:
+    pass
+
 import os
 from .mks_localization_model import MKSLocalizationModel
 from .bases.primitive import PrimitiveBasis

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -2,7 +2,7 @@ try:
     import pyfftw
     ## ensure that pyfftw is always imported before numpy to avoid
     ## https://github.com/materialsinnovation/pymks/issues/304
-except ImportError:
+except:
     pass
 
 import os

--- a/pymks/bases/abstract.py
+++ b/pymks/bases/abstract.py
@@ -1,7 +1,3 @@
-try:
-    import pyfftw # pylint: disable=import-error
-except:
-    pass
 import numpy as np
 
 
@@ -23,7 +19,6 @@ class _AbstractMicrostructureBasis(object):
         if domain is None:
             domain = [0, max(self.n_states)]
         self.domain = domain
-        self._pyfftw = self._module_exists('pyfftw')
         self._n_jobs = 1
 
     def check(self, X):

--- a/pymks/bases/abstract.py
+++ b/pymks/bases/abstract.py
@@ -25,14 +25,6 @@ class _AbstractMicrostructureBasis(object):
         if (np.min(X) < self.domain[0]) or (np.max(X) > self.domain[1]):
             raise RuntimeError("X must be within the specified domain")
 
-    def _module_exists(self, module_name):
-        try:
-            __import__(module_name)
-        except ImportError:
-            return False
-        else:
-            return True
-
     def discretize(self, X):
         raise NotImplementedError
 

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -1,0 +1,226 @@
+"""Wrapper module for PyFFTW and Numpy's fft.
+
+Provide a consistent interface for `rfftn`, `irfftn`, `fftn` and
+`ifftn` between Numpy's fft and PyFFTW. PyFFTW takes extra arguments
+that are not used by Numpy's fft module, for example, to call `rfftn`
+with PyFFTW,
+
+rfft(np.ascontiguousarray(data),
+     axes=axes,
+     threads=threads,
+     overwrite_input=True,
+     planner_effort='FFTW_ESTIMATE',
+     avoid_copy=True)
+
+while using Numpy, it is just
+
+rfft(data,
+     axes=axes,
+     threads=threads)
+
+Furthermore, this module takes care of the logic for selecting whether
+to use PyFFTW. If `PYMKS_USE_FFTW` is set in the environment or set to
+a positive value then PyFFTW will be used. If `PYMKS_USE_FFTW` is not
+set, then he following section in `setup.cfg` is used,
+
+[pymks]
+use-fftw = true
+
+If `PYMKS_USE_FFTW` is set to a negative value then Numpy's fft module
+is used. If `PYMKS_USE_FFTW` is unavailable and `use-fftw` is set to
+false or is unavailable, then Numpy's fft module is used.
+
+"""
+import configparser
+import os
+
+import numpy.fft as numpy_fft
+import numpy as np
+from pkg_resources import resource_string
+
+
+def config_use_pyfftw():
+    """Determine the value of `use-fftw` in setup.cfg.
+
+    Returns:
+      boolean value based on `use-fftw` in setup.cfg
+    """
+    config_string = resource_string('pymks', '../setup.cfg').decode('utf-8')
+    parser = configparser.ConfigParser()
+    parser.read_string(config_string)
+    if parser.has_option('pymks', 'use-fftw'):
+        return parser.getboolean('pymks', 'use-fftw')
+    else:
+        return False
+
+
+def env_use_pyfftw():
+    """Determine the value of the `PYMKS_USE_FFTW` environment variable.
+
+    Returns:
+      (defined, value): `defined` is bool depending on whether
+        `PYMKS_USE_FFTW` is defined, `value` is the bool value it's set
+        to (positive if undetermined)
+    """
+    from distutils.util import strtobool
+    env_var = 'PYMKS_USE_FFTW'
+    defined = env_var in os.environ
+    if defined:
+        env_string = os.environ[env_var]
+        try:
+            value = strtobool(env_string)
+        except ValueError:
+            value = True
+    else:
+        value = False
+    return defined, value
+
+
+def import_pyfftw():
+    """Isolate pyfftw import
+
+    Returns:
+      the pyfftw.builders module
+    """
+    import pyfftw.builders as pyfftw_fft
+    return pyfftw_fft
+
+
+def choose_fftmodule():
+    """Select either PyFFTW or Numpy's FFT
+
+    Logic is:
+      - pyfftw when `PYMKS_USE_FFT` is defined and positive
+      - pyfftw when `PYMKS_USE_FFT` is defined and undetermined
+      - numpy when `PYMKS_USE_FFT` is defined and negative
+      - pyfftw when `PYMKS_USE_FFT` is not defined and config has `use_fftw = true`
+      - numpy otherwise
+
+    Returns:
+      either `pyfftw.builders` or `numpy.fft` depending on logic
+    """
+    env_defined, env_value = env_use_pyfftw()
+    if env_defined:
+        if env_value:
+            return import_pyfftw()
+        else:
+            return numpy_fft
+    elif config_use_pyfftw():
+        return import_pyfftw()
+    else:
+        return numpy_fft
+
+FFTMODULE = choose_fftmodule()
+
+# def arg_wrap(fft_func, **extra_kwargs):
+#     """Return a wrapper function for Numpy's fft and PyFFTW.
+
+#     Args:
+#       fft_func: rfftn, irfftn, fftn ifftn from either numpy.fft or
+#         pymks.builders
+#       extra_kwargs: extra_args that are not default, useful for
+#         passing the over_write_input=True argument as it is not
+#         consistent for pyfftw.
+
+#     Returns:
+#       the wrapper function
+#     """
+#     using_pyfftw = FFTMODULE.__name__.split('.')[0] == 'pyfftw'
+
+def arg_wrap(fft_func, **extra_args):
+    """Decorator to add kwargs based on fft suite.
+
+    Args:
+      fft_func: the fft function to arg wrap
+      extra_args: extra args to add to the PyFFTW call
+
+    Returns:
+      the wrapped function
+    """
+
+    using_fftw = FFTMODULE.__name__.split('.')[0] == 'pyfftw'
+    def wrapper(data, axes=None, **kwargs):
+        """Wrapper function for Numpy's fft and PyFFTW
+
+        Args:
+          data: data to transform
+          fftmodule: either numpy.fft or pyfftw.builders
+          threads: the threads argument
+          extra_args: extra args to add
+
+        Returns:
+          the transformed data
+        """
+        if using_fftw:
+            kwargs.update(dict(planner_effort='FFTW_ESTIMATE',
+                               avoid_copy=False))
+            kwargs.update(extra_args)
+            return fft_func(np.ascontiguousarray(data), axes=axes, **kwargs)()
+        else:
+            kwargs.pop('threads')
+            return fft_func(data, axes=axes, **kwargs)
+    return wrapper
+
+def arg_wrap_overwrite(fft_func):
+    """Add the overwrite_input=True argument to arg_wrap
+
+    Args:
+      fft_func: the fft function to arg wrap
+
+    Returns:
+      the wrapped function
+    """
+    return arg_wrap(fft_func, overwrite_input=True)
+
+@arg_wrap_overwrite
+def rfftn(data, axes=None, **kwargs):
+    """Real Fourier transform wrapper
+
+    Args:
+      X: microstructure
+      axes: the axes over which to perform the transform
+
+    Returns:
+      the transformation
+    """
+    return FFTMODULE.rfftn(data, axes=axes, **kwargs)
+
+@arg_wrap
+def irfftn(data, axes=None, axes_shape=None, **kwargs):
+    """Inverse real Fourier transform wrapper
+
+    Args:
+      data: data to transform
+      axes: the axes over which to perform the transform
+      axes_shape: the axes shape
+
+    Returns:
+      the transformation
+    """
+    return FFTMODULE.irfftn(data, axes=axes, s=axes_shape, **kwargs)
+
+@arg_wrap_overwrite
+def fftn(data, axes=None, **kwargs):
+    """Fourier transform wrapper
+
+    Args:
+      data: microstructure
+      axes: the axes over which to perform the transform
+
+    Returns:
+      the transformation
+    """
+    return FFTMODULE.fftn(data, axes=axes, **kwargs)
+
+@arg_wrap_overwrite
+def ifftn(data, axes=None, **kwargs):
+    """Inverse Fourier transform wrapper
+
+    Args:
+      data: microstructure
+      axes: the axes over which to perform the transform
+
+    Returns:
+      the transformation
+    """
+    return FFTMODULE.ifftn(data, axes=axes, **kwargs)

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -111,21 +111,6 @@ def choose_fftmodule():
 
 FFTMODULE = choose_fftmodule()
 
-# def arg_wrap(fft_func, **extra_kwargs):
-#     """Return a wrapper function for Numpy's fft and PyFFTW.
-
-#     Args:
-#       fft_func: rfftn, irfftn, fftn ifftn from either numpy.fft or
-#         pymks.builders
-#       extra_kwargs: extra_args that are not default, useful for
-#         passing the over_write_input=True argument as it is not
-#         consistent for pyfftw.
-
-#     Returns:
-#       the wrapper function
-#     """
-#     using_pyfftw = FFTMODULE.__name__.split('.')[0] == 'pyfftw'
-
 def arg_wrap(fft_func, **extra_args):
     """Decorator to add kwargs based on fft suite.
 

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -81,6 +81,7 @@ def import_pyfftw():
     Returns:
       the pyfftw.builders module
     """
+    raise RuntimeError("Using PyFFTW!")
     import pyfftw.builders as pyfftw_fft
     return pyfftw_fft
 

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -81,7 +81,6 @@ def import_pyfftw():
     Returns:
       the pyfftw.builders module
     """
-    raise RuntimeError("Using PyFFTW!")
     import pyfftw.builders as pyfftw_fft
     return pyfftw_fft
 

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -156,7 +156,7 @@ def arg_wrap(fft_func, **extra_args):
             kwargs.update(extra_args)
             return fft_func(np.ascontiguousarray(data), axes=axes, **kwargs)()
         else:
-            kwargs.pop('threads')
+            kwargs.pop('threads', None)
             return fft_func(data, axes=axes, **kwargs)
     return wrapper
 

--- a/pymks/bases/fftmodule.py
+++ b/pymks/bases/fftmodule.py
@@ -5,23 +5,22 @@ Provide a consistent interface for `rfftn`, `irfftn`, `fftn` and
 that are not used by Numpy's fft module, for example, to call `rfftn`
 with PyFFTW,
 
-rfft(np.ascontiguousarray(data),
-     axes=axes,
-     threads=threads,
-     overwrite_input=True,
-     planner_effort='FFTW_ESTIMATE',
-     avoid_copy=True)
+    rfft(np.ascontiguousarray(data),
+         axes=axes,
+         threads=threads,
+         overwrite_input=True,
+         planner_effort='FFTW_ESTIMATE',
+         avoid_copy=True)
 
 while using Numpy, it is just
 
-rfft(data,
-     axes=axes,
-     threads=threads)
+    rfft(data,
+         axes=axes,)
 
 Furthermore, this module takes care of the logic for selecting whether
-to use PyFFTW. If `PYMKS_USE_FFTW` is set in the environment or set to
+to use PyFFTW. If `PYMKS_USE_FFTW` is set in the environment and set to
 a positive value then PyFFTW will be used. If `PYMKS_USE_FFTW` is not
-set, then he following section in `setup.cfg` is used,
+set, then the following section in `setup.cfg` is used,
 
 [pymks]
 use-fftw = true

--- a/pymks/bases/imag_ffts.py
+++ b/pymks/bases/imag_ffts.py
@@ -1,9 +1,5 @@
 from .abstract import _AbstractMicrostructureBasis
-try:
-    import pyfftw.builders as fftmodule
-except:
-    import numpy.fft as fftmodule
-import numpy as np
+from .fftmodule import ifftn, fftn
 
 
 class _ImagFFTBasis(_AbstractMicrostructureBasis):
@@ -21,14 +17,7 @@ class _ImagFFTBasis(_AbstractMicrostructureBasis):
         Returns:
             Fourier transform of X
         """
-        if self._pyfftw:
-
-            return fftmodule.fftn(np.ascontiguousarray(X),
-                                  axes=self._axes, threads=self._n_jobs,
-                                  planner_effort='FFTW_ESTIMATE',
-                                  overwrite_input=True, avoid_copy=True)()
-        else:
-            return fftmodule.fftn(X, axes=self._axes)
+        return fftn(X, axes=self._axes, threads=self._n_jobs)
 
     def _ifftn(self, X):
         """Standard iFFT algorithm
@@ -39,11 +28,4 @@ class _ImagFFTBasis(_AbstractMicrostructureBasis):
         Returns:
             Inverse Fourier transform of X
         """
-        if self._pyfftw:
-            return fftmodule.ifftn(np.ascontiguousarray(X),
-                                   axes=self._axes, threads=self._n_jobs,
-                                   planner_effort='FFTW_ESTIMATE',
-                                   overwrite_input=True,
-                                   avoid_copy=True)()
-        else:
-            return fftmodule.ifftn(X, axes=self._axes)
+        return ifftn(X, axes=self._axes, threads=self._n_jobs)

--- a/pymks/bases/real_ffts.py
+++ b/pymks/bases/real_ffts.py
@@ -1,9 +1,5 @@
 from .abstract import _AbstractMicrostructureBasis
-try:
-    import pyfftw.builders as fftmodule
-except:
-    import numpy.fft as fftmodule
-import numpy as np
+from .fftmodule import rfftn, irfftn
 
 
 class _RealFFTBasis(_AbstractMicrostructureBasis):
@@ -21,13 +17,7 @@ class _RealFFTBasis(_AbstractMicrostructureBasis):
         Returns:
             Fourier transform of X
         """
-        if self._pyfftw:
-            return fftmodule.rfftn(np.ascontiguousarray(X),
-                                   axes=self._axes, threads=self._n_jobs,
-                                   planner_effort='FFTW_ESTIMATE',
-                                   overwrite_input=True, avoid_copy=True)()
-        else:
-            return fftmodule.rfftn(X, axes=self._axes)
+        return rfftn(X, axes=self._axes, threads=self._n_jobs)
 
     def _ifftn(self, X):
         """Real irFFT algorithm
@@ -38,12 +28,4 @@ class _RealFFTBasis(_AbstractMicrostructureBasis):
         Returns:
             Inverse Fourier transform of X
         """
-        if self._pyfftw:
-            return fftmodule.irfftn(np.ascontiguousarray(X),
-                                    s=self._axes_shape, axes=self._axes,
-                                    threads=self._n_jobs,
-                                    planner_effort='FFTW_ESTIMATE',
-                                    avoid_copy=True)().real
-        else:
-            return fftmodule.irfftn(X, axes=self._axes,
-                                    s=self._axes_shape).real
+        return irfftn(X, axes_shape=self._axes_shape, axes=self._axes, threads=self._n_jobs).real

--- a/pymks/mks_homogenization_model.py
+++ b/pymks/mks_homogenization_model.py
@@ -96,8 +96,8 @@ class MKSHomogenizationModel(MKSStructureAnalysis):
                 correlations will not be calculated as part of the fit and
                 predict methods. The spatial correlations can be passed as `X`
                 to both methods, default is True.
-            n_jobs (int, optional): number of parallel jobs to run. only used
-                if pyfftw is install.
+            n_jobs (int, optional): number of parallel jobs to run, only used
+                if pyfftw is installed.
             store_correlations (boolean, optional): indicate if spatial
                 correlations should be stored
             mean_center (boolean, optional): If true the data will be mean

--- a/pymks/mks_localization_model.py
+++ b/pymks/mks_localization_model.py
@@ -66,8 +66,8 @@ class MKSLocalizationModel(LinearRegression):
         Args:
             basis (class): an instance of a bases class.
             n_states (int, optional): number of local states
-            n_jobs (int, optional): number of parallel jobs to run. only used
-                if pyfftw is install.
+            n_jobs (int, optional): number of parallel jobs to run, only used
+                if pyfftw is installed.
             lstsq_rcond (float, optional): rcond argument to scipy.linalg.lstsq
                 function. Defaults to 4 orders of magnitude above machine
                 epsilon.

--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -73,8 +73,8 @@ class MKSStructureAnalysis(BaseEstimator):
             store_correlations (boolean, optional): If true the computed
                 2-point statistics will be saved as an attributes
                 fit_correlations and transform_correlations.
-            n_jobs (int, optional): number of parallel jobs to run. only used
-                if pyfftw is install.
+            n_jobs (int, optional): number of parallel jobs to run, only used
+                if pyfftw is installed.
             mean_center (boolean, optional): If true the data will be mean
                 centered before dimensionality reduction is computed.
         """

--- a/pymks/stats.py
+++ b/pymks/stats.py
@@ -19,8 +19,8 @@ def autocorrelate(X, basis, periodic_axes=[], n_jobs=1, confidence_index=None,
         basis (class): an instance of a bases class
         periodic_axes (list, optional): axes that are periodic. (0, 2) would
             indicate that axes x and z are periodic in a 3D microstrucure.
-        n_jobs (int, optional): number of parallel jobs to run. only used if
-            pyfftw is install.
+        n_jobs (int, optional): number of parallel jobs to run, only used if
+            pyfftw is installed.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
         autocorrelations (list, optional): list of spatial autocorrelations to
@@ -69,8 +69,8 @@ def crosscorrelate(X, basis, periodic_axes=None, n_jobs=1,
         basis (class): an instance of a bases class
         periodic_axes (list, optional): axes that are periodic. (0, 2) would
             indicate that axes x and z are periodic in a 3D microstrucure.
-        n_jobs (int, optional): number of parallel jobs to run. only used if
-            pyfftw is install.
+        n_jobs (int, optional): number of parallel jobs to run, only used if
+            pyfftw is installed.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
         crosscorrelations (list, optional): list of cross-correlations to
@@ -144,8 +144,8 @@ def correlate(X, basis, periodic_axes=None, n_jobs=1,
         basis (class): an instance of a bases class
         periodic_axes (list, optional): axes that are periodic. (0, 2) would
             indicate that axes x and z are periodic in a 3D microstrucure.
-        n_jobs (int, optional): number of parallel jobs to run. only used if
-            pyfftw is install.
+        n_jobs (int, optional): number of parallel jobs to run, only used if
+            pyfftw is installed.
         confidence_index (ND array, optional): array with same shape as X used
             to assign a confidence value for each data point.
         correlations (list, optional): list of  spatial _check_shapes to

--- a/pymks/tests/test_stats.py
+++ b/pymks/tests/test_stats.py
@@ -293,21 +293,15 @@ def test_gsh_basis_normalization():
 
 
 def test_stats_in_parallel():
-    import time
     from pymks.bases import PrimitiveBasis
     from pymks.stats import correlate
     from pymks.datasets import make_microstructure
     p_basis = PrimitiveBasis(5)
-    if p_basis._pyfftw:
-        X = make_microstructure(n_samples=5, n_phases=3)
-        t = []
-        for i in range(1, 4):
-            t_start = time.time()
-            correlate(X, p_basis, n_jobs=i)
-            t.append(time.time() - t_start)
-            assert t == sorted(t, reverse=True)
-    else:
-        pass
+    X = make_microstructure(n_samples=5, n_phases=3)
+    X_corr_actual = correlate(X, p_basis)
+    for i in range(1, 4):
+        X_corr_test = correlate(X, p_basis, n_jobs=i)
+        assert np.allclose(X_corr_actual, X_corr_test)
 
 
 def test_autocorrelate_with_specific_correlations():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy
 numpy
 scikit-learn
 matplotlib
+configparser
 
 ## packages for testing pymks
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ description-file = README.md
 [tool:pytest]
 addopts = --doctest-modules --ignore=setup.py -r s --cov=pymks --cov-report term-missing
 testpaths = pymks
+[pymks]
+use-fftw = false

--- a/setup.py
+++ b/setup.py
@@ -74,4 +74,5 @@ setup(name='pymks',
       url='http://pymks.org',
       packages=find_packages(),
       package_data={'': ['tests/*.py']},
-      install_requires=['scipy', 'numpy', 'scikit-learn', 'matplotlib'])
+      install_requires=['scipy', 'numpy', 'scikit-learn', 'matplotlib'],
+      data_files=['setup.cfg'])

--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,5 @@ setup(name='pymks',
       url='http://pymks.org',
       packages=find_packages(),
       package_data={'': ['tests/*.py']},
-      install_requires=['scipy', 'numpy', 'scikit-learn', 'matplotlib'],
+      install_requires=['scipy', 'numpy', 'scikit-learn', 'matplotlib', 'configparser'],
       data_files=['setup.cfg'])


### PR DESCRIPTION
Use Numpy's fft by default unless the `PYMKS_USE_FFTW` environment variable is set or `use-fftw` is set in setup.cfg on install. PyFFTW is quite fragile so it is best to explicitly use PyFFTW rather than use it by default if installed.

Other changes include modifying a test in  `pymks/tests/test_stats.py`, which seemed to not be deterministic. It assumed that the run time would be less for larger number of threads, which is heavily dependent on resources on the current workstation. Under some circumstances the run time could be greater with more threads.

Address #325
