### PR TITLE
adjusting to sklearn 0.20.2

### DIFF
--- a/pymks/mks_structure_analysis.py
+++ b/pymks/mks_structure_analysis.py
@@ -1,6 +1,6 @@
 from pymks.stats import correlate
 from sklearn.base import BaseEstimator
-from sklearn.decomposition import RandomizedPCA
+from sklearn.decomposition import PCA
 import numpy as np
 
 
@@ -87,7 +87,7 @@ class MKSStructureAnalysis(BaseEstimator):
         if basis is not None:
             self.basis._n_jobs = n_jobs
         if self.dimension_reducer is None:
-            self.dimension_reducer = RandomizedPCA(copy=False)
+            self.dimension_reducer = RandomizedPCA(copy=False,svd_solver="randomized")
         if n_components is None:
             n_components = self.dimension_reducer.n_components
         if n_components is None:

--- a/pymks/tools.py
+++ b/pymks/tools.py
@@ -7,7 +7,7 @@ except ImportError:
 import matplotlib.colors as colors
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from sklearn.learning_curve import learning_curve
+from sklearn.model_selection import learning_curve
 from .stats import _auto_correlations
 from .stats import _cross_correlations
 import numpy as np


### PR DESCRIPTION
There are some changes in the sklearn API.
This works formally (tested with sklearn 0.20.2) but I don't know if the behavior is still correct since I never worked with pyMKS before.
From https://scikit-learn.org/0.18/whats_new.html

> Class decomposition.RandomizedPCA is now factored into decomposition.PCA and it is available calling with parameter svd_solver='randomized'. The default number of n_iter for 'randomized' has changed to 4. The old behavior of PCA is recovered by svd_solver='full'.

So, according to my understanding, you would need to change `RandomizedPCA(copy=False,svd_solver="randomized")` to `RandomizedPCA(copy=False,svd_solver="full")` in pymks/mks_structure_analysis.py if you want to recover exactly the old behavior.