### PR TITLE
Identify and close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not
+  had no activity in the last year. It will be closed if no further
+  activity occurs in the next 30 days. Thank you for your
+  contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,8 +10,8 @@ exemptLabels:
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not
-  had no activity in the last year. It will be closed if no further
+  This issue has been automatically marked as stale because it has had
+  no activity in the last year. It will be closed if no further
   activity occurs in the next 30 days. Thank you for your
   contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable


### PR DESCRIPTION
Mark issues as wontfix after 365 days of no activity and then close issue if no activity for a subsequent 30 days.