### PR TITLE
fix: ensure zero_pad returns the correct chunks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,5 +33,6 @@ jobs:
       - run:
           name: run tests
           command: |
+            set -e
             source activate pymks
             python -c "import pymks;pymks.test()"

--- a/environment.yml
+++ b/environment.yml
@@ -2,17 +2,17 @@ name: pymks
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
-  - sfepy=2018.2
-  - scipy=1.2.1
-  - dask=1.1.1
+  - python=3.7
+  - sfepy=2019.2
+  - scipy=1.4.1
+  - dask=2.10.2
   - scikit-learn=0.20.2
   - toolz=0.10.0
   - coverage=4.5.4
-  - matplotlib=3.1.1
-  - numpy=1.17.1
-  - pytest=5.1.1
-  - pytest-cov=2.7.1
-  - notebook=6.0.1
-  - dask-ml=1.0.0
-  - nbval=0.9.1
+  - matplotlib=3.1.2
+  - numpy=1.18.1
+  - pytest=5.3.5
+  - pytest-cov=2.8.1
+  - notebook=6.0.3
+  - dask-ml=1.2.0
+  - nbval=0.9.4

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.7
   - sfepy=2019.2
   - scipy=1.4.1
-  - dask=2.10.2
+  - dask=2.10.1
   - scikit-learn=0.20.2
   - toolz=0.10.0
   - coverage=4.5.4

--- a/pymks/fmks/localization.py
+++ b/pymks/fmks/localization.py
@@ -26,8 +26,16 @@ from toolz.curried import pipe
 from toolz.curried import map as fmap
 from sklearn.base import RegressorMixin, TransformerMixin, BaseEstimator
 
-from .func import curry, array_from_tuple, rechunk
-from .func import dafftshift, dafftn, daifftn, daifftshift
+from .func import (
+    curry,
+    array_from_tuple,
+    rechunk,
+    dafftshift,
+    dafftn,
+    daifftn,
+    daifftshift,
+    zero_pad,
+)
 
 
 @curry
@@ -313,61 +321,11 @@ def coeff_resize(coeff, shape):
     return pipe(
         coeff,
         coeff_to_real,
-        zero_pad(shape=shape + coeff.shape[-1:]),
-        coeff_to_frequency,
-    )
-
-
-@curry
-def zero_pad(arr, shape):
-    """Zero pad an array with zeros
-
-    Args:
-      arr: the array to pad
-      shape: the shape of the new array
-
-    Returns:
-      the new padded version of the array
-
-    >>> print(
-    ...     zero_pad(
-    ...         np.arange(4).reshape([1, 2, 2, 1]),
-    ...         (1, 4, 5, 1)
-    ...     )[0,...,0].compute()
-    ... )
-    [[0 0 0 0 0]
-     [0 0 0 1 0]
-     [0 0 2 3 0]
-     [0 0 0 0 0]]
-    >>> print(zero_pad(np.arange(4).reshape([2, 2]), (4, 5)).compute())
-    [[0 0 0 0 0]
-     [0 0 0 1 0]
-     [0 0 2 3 0]
-     [0 0 0 0 0]]
-    >>> zero_pad(zero_pad(np.arange(4).reshape([2, 2]), (4, 5, 1)))
-    Traceback (most recent call last):
-    ...
-    RuntimeError: length of shape is incorrect
-    >>> zero_pad(zero_pad(np.arange(4).reshape([2, 2]), (1, 2)))
-    Traceback (most recent call last):
-    ...
-    RuntimeError: resize shape is too small
-    """
-    if len(shape) != len(arr.shape):
-        raise RuntimeError("length of shape is incorrect")
-
-    if not np.all(shape >= arr.shape):
-        raise RuntimeError("resize shape is too small")
-
-    return pipe(
-        np.array(shape) - np.array(arr.shape),
-        lambda x: np.concatenate(
-            ((x - (x // 2))[..., None], (x // 2)[..., None]), axis=1
+        zero_pad(
+            shape=shape + coeff.shape[-1:],
+            chunks=((-1,) * len(shape)) + (coeff.chunks[-1],),
         ),
-        fmap(tuple),
-        tuple,
-        lambda x: da.pad(arr, x, "constant", constant_values=0),
-        lambda x: da.rechunk(x, chunks=x.shape),
+        coeff_to_frequency,
     )
 
 


### PR DESCRIPTION
Ensure that the zero_pad function returns Dask arrays with the correct
chunking. da.pad doesn't know how to chunk the new padded data
correctly and, thus, zero_pad now takes a chunks argument.