### PR TITLE
build(conda): update conda yml due to circle fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           command: |
             conda env create -f environment.yml
             source activate pymks
+
       - run:
           name: Activate env
           command: |
@@ -29,10 +30,17 @@ jobs:
             apt-get --yes install libgl1-mesa-glx
             apt-get --yes install libxrender1
 
-
+      # only run select notebooks due to possible memory issues
       - run:
           name: run tests
           command: |
             set -e
             source activate pymks
-            python -c "import pymks;pymks.test()"
+            python setup.py develop
+            py.test pymks
+            py.test notebooks/elasticity.ipynb
+            py.test notebooks/filter.ipynb
+            py.test notebooks/intro.ipynb
+            py.test notebooks/multiphase.ipynb
+            py.test notebooks/stats_checker_board.ipynb
+            py.test notebooks/stress.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,4 @@ ENV/
 .local/
 
 domain.vtk
-notebooks/dask-worker-space
-notebooks/domain.vtk
+dask-worker-space

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - sfepy=2019.2
+  - sfepy=2019.4
   - scipy=1.4.1
   - dask=2.10.1
-  - scikit-learn=0.20.2
+  - scikit-learn=0.22.1
   - toolz=0.10.0
   - coverage=4.5.4
-  - matplotlib=3.1.2
+  - matplotlib=3.1.3
   - numpy=1.18.1
   - pytest=5.3.5
   - pytest-cov=2.8.1
   - notebook=6.0.3
   - dask-ml=1.2.0
-  - nbval=0.9.4
+  - nbval=0.9.5

--- a/notebooks/sanitize.cfg
+++ b/notebooks/sanitize.cfg
@@ -10,3 +10,11 @@ replace: <matplotlib.figure.Figure>
 [regex]
 regex: <lambda> at [0-9a-z]{14}
 replace: <lambda>
+
+[regex]
+regex: ponents [0-9]{1,2}
+replace: ponents x
+
+[regex]
+regex: ponents=[0-9]{1,2}
+replace: ponents=x


### PR DESCRIPTION
Fix #410

Conda build was failing on Circle CI. This is to do with the Conda
solver getting muddled with Sfepy, Dask and dependencies. Eventually
found a working version of Sfepy and Python and then Dask.