### PR TITLE
feat: generator function for multiphase microstructures

### DIFF
--- a/pymks/fmks/func.py
+++ b/pymks/fmks/func.py
@@ -87,7 +87,7 @@ def iterate_times(func, times, value):
 
 
 @curry
-def map_blocks(func, data, chunks=None):
+def map_blocks(func, data, chunks=None, dtype=None):
     """Curried version of Dask's map_blocks
 
     Args:
@@ -102,7 +102,7 @@ def map_blocks(func, data, chunks=None):
     >>> f(da.arange(4, chunks=(2,)))
     dask.array<lambda, shape=(4,), dtype=int64, chunksize=(2,), chunktype=numpy.ndarray>
     """
-    return da.map_blocks(func, data, chunks=chunks)
+    return da.map_blocks(func, data, chunks=chunks, dtype=dtype)
 
 
 allclose = curry(np.allclose)  # pylint: disable=invalid-name
@@ -231,19 +231,21 @@ def flatten(data):
     return data.reshape(data.shape[0], -1)
 
 
-def rechunk(data, chunks):
+@curry
+def rechunk(chunks, data):
     """An agnostic rechunk for numpy or dask
 
     Required as from_array no longer accepts dask arrays.
 
     Args:
-      data: either a numpy or dask array
       chunks: the new chunk shape
+      data: either a numpy or dask array
+
 
     Returns:
       a rechunked dask array
 
-    >>> rechunk(np.arange(10).reshape((2, 5)), (1, 5)).chunks
+    >>> rechunk((1, 5), np.arange(10).reshape((2, 5))).chunks
     ((1, 1), (5,))
 
     """
@@ -274,7 +276,7 @@ def make_da(func):
     """
 
     def wrapper(arr, *args, **kwargs):
-        return func(rechunk(arr, chunks=arr.shape), *args, **kwargs)
+        return func(rechunk(arr.shape, arr), *args, **kwargs)
 
     return wrapper
 

--- a/pymks/fmks/localization.py
+++ b/pymks/fmks/localization.py
@@ -441,7 +441,7 @@ class LocalizationRegressor(BaseEstimator, RegressorMixin):
         """
         self.y_data_shape = y_data.shape
         y_data_reshape = reshape(y_data, x_data.shape[:-1])
-        y_data_da = rechunk(y_data_reshape, chunks=x_data.chunks[:-1])
+        y_data_da = rechunk(x_data.chunks[:-1], y_data_reshape)
         self.coeff = fit_disc(x_data, y_data_da, self.redundancy_func)
         return self
 

--- a/pymks/fmks/tests/test_multiphase.py
+++ b/pymks/fmks/tests/test_multiphase.py
@@ -1,0 +1,84 @@
+"""Test the multiphase microstructure generator
+
+"""
+
+import numpy as np
+
+import pytest
+import dask.array as da
+
+from pymks.fmks.data.multiphase import generate
+
+
+def test_chunking():
+    """Test that the generated microstructue is chunked correctly
+
+    """
+    da.random.seed(10)
+    data = generate(
+        shape=(5, 11, 11), grain_size=(3, 4), volume_fraction=(0.5, 0.5), chunks=2
+    )
+    assert data.shape == (5, 11, 11)
+    assert data.chunks == ((2, 2, 1), (11,), (11,))
+
+
+def test_2d():
+    """Regression test for microstructure phases
+    """
+    da.random.seed(10)
+    data = generate(shape=(1, 4, 4), grain_size=(4, 4), volume_fraction=(0.5, 0.5))
+    assert np.allclose(data, [[[0, 0, 0, 0], [1, 0, 1, 1], [1, 1, 1, 1], [1, 0, 0, 0]]])
+
+
+def test_1d():
+    """Test that 1D works
+    """
+    da.random.seed(10)
+    data = generate(shape=(1, 10), grain_size=(4,), volume_fraction=(0.5, 0.5))
+    assert np.allclose(data, [0, 0, 0, 0, 1, 0, 1, 1, 1, 1])
+
+
+def test_grain_size():
+    """
+    Test incompatible grain_size and shape
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        da.random.seed(10)
+        generate(shape=(1, 10, 10), grain_size=(4,), volume_fraction=(0.5, 0.5))
+    assert str(excinfo.value) == "`shape` should be of length `len(grain_size) + 1`"
+
+
+def test_volume_fraction():
+    """Test incoherent volume_fraction
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        da.random.seed(10)
+        generate(shape=(1, 10), grain_size=(2,), volume_fraction=(0.4, 0.4, 0.4))
+    assert str(excinfo.value) == "The terms in the volume fraction list should sum to 1"
+
+
+def test_3d():
+    """Test 3D
+
+    Also tests for bug that occured when chunks and sample size are
+    different.
+
+    """
+    da.random.seed(10)
+    data = generate(
+        shape=(5, 5, 5, 5),
+        grain_size=(1, 5, 1),
+        volume_fraction=(0.3, 0.3, 0.4),
+        chunks=2,
+    )
+    assert data.chunks == ((2, 2, 1), (5,), (5,), (5,))
+    assert np.allclose(
+        data[0, 1],
+        [
+            [0, 1, 0, 2, 2],
+            [0, 1, 0, 2, 2],
+            [0, 1, 1, 2, 1],
+            [0, 1, 2, 2, 0],
+            [0, 1, 2, 2, 0],
+        ],
+    )


### PR DESCRIPTION
Add a generator function for multiphase microstructure where the rough grain size is randomly generated. It generates the data in parallel:

 - Remove redundant n_phases argument in favor of just using
   volume_fraction to determine the number of phases

 - Ensure exceptions are raised before compute() is required.

 - Add test for exceptions, 1D, 2D, 3D and chunking

 - Remove keyword arguments other than chunks to be more explicit

TODO
 - [x] ensure this is truly parallel by examining the graph