### PR TITLE
docs: update for 0.4 API

### DIFF
--- a/doc/API.rst
+++ b/doc/API.rst
@@ -7,9 +7,12 @@ API
 .. toctree::
    :maxdepth: 1
 
-   MKSmodels.rst
-   spatial_statistics.rst
    datageneration.rst
    bases.rst
-   tools.rst
-   testing.rst
+   spatial_statistics.rst
+   MKSmodels.rst
+
+
+   ..
+      tools.rst
+      testing.rst

--- a/doc/MKSmodels.rst
+++ b/doc/MKSmodels.rst
@@ -1,18 +1,16 @@
-MKS Models
-==========
+Localization
+============
 
-MKSStructureAnalysis
-----------------------
-.. autoclass:: pymks.mks_structure_analysis.MKSStructureAnalysis
+LocalizationRegressor
+---------------------
+.. autoclass:: pymks.LocalizationRegressor
    :members:
 
-MKSHomogenizationModel
-----------------------
-.. autoclass:: pymks.mks_homogenization_model.MKSHomogenizationModel
+ReshapeTransformer
+------------------
+.. autoclass:: pymks.ReshapeTransformer
    :members:
 
-MKSLocalizationModel
---------------------
-.. autoclass:: pymks.mks_localization_model.MKSLocalizationModel
-   :members:
-
+coeff_to_real
+-------------
+.. autofunction:: pymks.coeff_to_real

--- a/doc/bases.rst
+++ b/doc/bases.rst
@@ -1,22 +1,12 @@
-Microstructure Bases
-====================
+Bases Transformers
+==================
 
-PrimitiveBasis
-------------------------
-.. autoclass:: pymks.bases.PrimitiveBasis
+PrimitiveTransformer
+--------------------
+.. autoclass:: pymks.PrimitiveTransformer
    :members:
 
-LegendreBasis
--------------
-.. autoclass:: pymks.bases.LegendreBasis
-   :members:
-
-FourierBasis
--------------
-.. autoclass:: pymks.bases.FourierBasis
-   :members:
-
-GSHBasis
--------------
-.. autoclass:: pymks.bases.GSHBasis
+LegendreTransformer
+-------------------
+.. autoclass:: pymks.LegendreTransformer
    :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,9 +29,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
-              'sphinxcontrib.napoleon',
               'nbsphinx',
-              'm2r']
+              'm2r2']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -53,6 +52,42 @@ copyright = u'2015, David Brough'
 # built documents.
 #
 # The short X.Y version.
+
+# Sfepy needs to be completely mocked for the docs as it can't be
+# install with pip.
+
+MOCK_MODULES = [
+    'sfe',
+    'sfepy',
+    'sfepy.base',
+    'sfepy.discrete',
+    'sfepy.discrete.fem',
+    'sfepy.discrete.conditions',
+    'sfepy.terms',
+    'sfepy.solvers',
+    'sfepy.solvers.ls',
+    'sfepy.solvers.nls',
+    'sfepy.discrete.fem.periodic',
+    'sfepy.mesh',
+    'sfepy.mesh.mesh_generators',
+    'sfepy.mechanics',
+    'sfepy.mechanics.matcoefs',
+    'sfepy.base.base'
+]
+
+import mock
+
+for module in MOCK_MODULES:
+    sys.modules[module] = mock.Mock()
+
+# goptions is assigned to so needs to support assignment
+
+m = mock.MagicMock()
+d = dict(key='value')
+m.__getitem__.side_effect = d.__getitem__
+sys.modules['sfepy.base.goptions'] = m
+
+
 import pymks
 version = pymks.__version__
 # The full version, including alpha/beta/rc tags.
@@ -72,6 +107,7 @@ release = pymks.__version__
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 autoclass_content = 'both'
+
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/doc/datageneration.rst
+++ b/doc/datageneration.rst
@@ -1,50 +1,22 @@
 Data Generation
 ===============
 
-make_microstructure
+generate_delta
+--------------
+.. autofunction:: pymks.generate_delta
+
+multiphase
+----------
+.. autofunction:: pymks.generate_multiphase
+
+generate_checkerboard
+---------------------
+.. autofunction:: pymks.generate_checkerboard
+
+solve_cahn_hilliard
 -------------------
-.. autofunction:: pymks.datasets.make_microstructure
+.. autofunction:: pymks.solve_cahn_hilliard
 
-make_delta_microstructures
---------------------------
-.. autofunction:: pymks.datasets.make_delta_microstructures
-
-make_checkerboard_microstructure
---------------------------------
-.. autofunction:: pymks.datasets.make_checkerboard_microstructure
-
-make_cahn_hilliard
-------------------
-.. autofunction:: pymks.datasets.make_cahn_hilliard
-
-Data Generation that Requires SfePy
------------------------------------
-
-make_elastic_FE_strain_random
------------------------------
-.. autofunction:: pymks.datasets.make_elastic_FE_strain_random
-
-make_elastic_FE_strain_delta
-----------------------------
-.. autofunction:: pymks.datasets.make_elastic_FE_strain_delta
-
-make_elastic_stiffness
-----------------------
-.. autofunction:: pymks.datasets.make_elastic_stiffness
-
-make_elastic_stress_random
---------------------------
-.. autofunction:: pymks.datasets.make_elastic_stress_random
-
-
-Simulations
------------
-Cahn-Hilliard
--------------
-.. autoclass:: pymks.datasets.cahn_hilliard_simulation.CahnHilliardSimulation
-   :members:
-
-Finite Element Elasticity
--------------------------
-.. autoclass:: pymks.datasets.elastic_FE_simulation.ElasticFESimulation
-   :members:
+elastic_fe
+----------
+.. autofunction:: pymks.solve_fe

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,10 +1,12 @@
-sphinx==1.7.0
-sphinx_bootstrap_theme==0.6.5
-numpy
-scipy
-scikit-learn
-sphinxcontrib-napoleon==0.6.1
-nbsphinx==0.3.3
+sphinx
+sphinx_bootstrap_theme
 pytest
+numpy
+toolz
+dask
 matplotlib
-m2r==0.1.13
+scikit-learn
+mock
+nbsphinx==0.5.1
+m2r2
+# require pandoc which is a haskell package

--- a/doc/spatial_statistics.rst
+++ b/doc/spatial_statistics.rst
@@ -1,14 +1,10 @@
 Spatial Statistics
 ==================
 
-autocorrelate
--------------
-.. autofunction:: pymks.stats.autocorrelate
+TwoPointCorrelation
+-------------------
+.. autoclass:: pymks.TwoPointCorrelation
 
-crosscorrelate
---------------
-.. autofunction:: pymks.stats.crosscorrelate
-
-correlate
----------
-.. autofunction:: pymks.stats.correlate
+FlattenTransformer
+------------------
+.. autoclass:: pymks.FlattenTransformer

--- a/index.ipynb
+++ b/index.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "### 2-Point Statistics\n",
     "\n",
-    " - [Checkerboard Microstructure](./notebooks/stats_checker_board.ipynb)\n",
+    " - [Checkerboard Microstructure](./notebooks/checkerboard.ipynb)\n",
     "\n",
     "### Homogenization\n",
     "   \n",
@@ -35,13 +35,6 @@
     " - [Technical Overview](notebooks/tech_overview.ipynb)\n",
     " - [Derivation of MKS localization](notebooks/derivation.ipynb)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -61,7 +54,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 - Update docs for new API "from pymks import x"
 - make docs build locally (still not tested on readthedocs)
 - need m2r2 now instead of m2r for markdown to rst rendering
 - needed to mock sfepy import