### PR TITLE
refactor: use unique names for generate and solve functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
   - nix-shell --pure --command "echo 'run nix-shell'"
 script:
   - nix-shell --pure --command "export PYMKS_USE_FFTW=$PYMKS_USE_FFTW; py.test --cov-fail-under=100"
-  - nix-shell --pure --command "pylint --rcfile=.pylintrc pymks/fmks pymks/fmks/tests"
-  - nix-shell --pure --command "flake8 pymks/fmks pymks/fmks/tests"
-  - nix-shell --pure --command "black --check pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "pylint --rcfile=.pylintrc pymks/__init__.py pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "flake8 pymks/__init__.py pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "black --check pymks/__init__.py pymks/fmks pymks/fmks/tests"

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -1,30 +1,37 @@
+"""PyMKS - the materials knowledge system in Python
+
+See the documenation for details at https://pymks.org
+"""
+
 try:
-    import pyfftw
-    ## ensure that pyfftw is always imported before numpy to avoid
-    ## https://github.com/materialsinnovation/pymks/issues/304
-except:
+    import pyfftw  # pylint: disable=unused-import; # noqa: F401
+
+    # ensure that pyfftw is always imported before numpy to avoid
+    # https://github.com/materialsinnovation/pymks/issues/304
+except ImportError:
     pass
 
 import os
-from .fmks.data.cahn_hilliard import solve as solve_cahn_hilliard
+from .fmks.data.cahn_hilliard import solve_cahn_hilliard
 from .fmks.plot import plot_microstructures
 from .fmks.bases.primitive import PrimitiveTransformer
 from .fmks.bases.legendre import LegendreTransformer
 from .fmks.localization import LocalizationRegressor
 from .fmks.localization import ReshapeTransformer
 from .fmks.localization import coeff_to_real
-from .fmks.data.delta import generate as generate_delta
-from .fmks.data.elastic_fe import solve as solve_fe
-from .fmks.data.multiphase import generate as generate_multiphase
+from .fmks.data.delta import generate_delta
+from .fmks.data.elastic_fe import solve_fe
+from .fmks.data.multiphase import generate_multiphase
 from .fmks.correlations import FlattenTransformer
 from .fmks.correlations import TwoPointCorrelation
-from .fmks.data.checkerboard import generate as generate_checkerboard
+from .fmks.data.checkerboard import generate_checkerboard
 
 from .mks_localization_model import MKSLocalizationModel
 from .bases.primitive import PrimitiveBasis
 from .bases.legendre import LegendreBasis
 from .mks_structure_analysis import MKSStructureAnalysis
 from .mks_homogenization_model import MKSHomogenizationModel
+
 MKSRegressionModel = MKSLocalizationModel
 DiscreteIndicatorBasis = PrimitiveBasis
 ContinuousIndicatorBasis = PrimitiveBasis
@@ -34,9 +41,10 @@ def test():
     r"""
     Run all the doctests available.
     """
-    import pytest
+    import pytest  # pylint: disable=import-outside-toplevel
+
     path = os.path.split(__file__)[0]
-    pytest.main(args=[path, '--doctest-modules', '-r s'])
+    pytest.main(args=[path, "--doctest-modules", "-r s"])
 
 
 def get_version():
@@ -45,35 +53,40 @@ def get_version():
     Returns:
       the package version number
     """
+    # pylint: disable=import-outside-toplevel
     from pkg_resources import get_distribution, DistributionNotFound
 
     try:
-        version = get_distribution(__name__.split('.')[0]).version # pylint: disable=no-member
-    except DistributionNotFound: # pragma: no cover
+        version = get_distribution(
+            __name__.split(".")[0]
+        ).version  # pylint: disable=no-member
+    except DistributionNotFound:  # pragma: no cover
         version = "unknown, try running `python setup.py egg_info`"
 
     return version
 
+
 __version__ = get_version()
 
-__all__ = ['__version__',
-           'test',
-           'solve_cahn_hilliard',
-           'plot_microstructures',
-           'PrimitiveTransformer',
-           'LocalizationRegressor',
-           'ReshapeTransformer',
-           'coeff_to_real'
-           'MKSLocalizationModel',
-           'PrimitiveBasis',
-           'LegendreBasis',
-           'MKSHomogenizationModel',
-           'MKSStructureAnalysis',
-           'generate_delta',
-           'LegendreTransformer',
-           'solve_fe',
-           'generate_multiphase',
-           'FlattenTransformer',
-           'TwoPointCorrelation',
-           'generate_checkerboard'
+__all__ = [
+    "__version__",
+    "test",
+    "solve_cahn_hilliard",
+    "plot_microstructures",
+    "PrimitiveTransformer",
+    "LocalizationRegressor",
+    "ReshapeTransformer",
+    "coeff_to_real",
+    "MKSLocalizationModel",
+    "PrimitiveBasis",
+    "LegendreBasis",
+    "MKSHomogenizationModel",
+    "MKSStructureAnalysis",
+    "generate_delta",
+    "LegendreTransformer",
+    "solve_fe",
+    "generate_multiphase",
+    "FlattenTransformer",
+    "TwoPointCorrelation",
+    "generate_checkerboard",
 ]

--- a/pymks/fmks/__init__.py
+++ b/pymks/fmks/__init__.py
@@ -1,4 +1,4 @@
-"""fMKS - functional matierals knowledge system.
+"""fMKS - functional materials knowledge system.
 
 See https://github.com/wd15/fmks
 

--- a/pymks/fmks/data/cahn_hilliard.py
+++ b/pymks/fmks/data/cahn_hilliard.py
@@ -148,7 +148,7 @@ def _check(x_data):
     return x_data
 
 
-def solve(x_data, n_steps=1, delta_x=0.25, delta_t=0.001, gamma=1.0):
+def solve_cahn_hilliard(x_data, n_steps=1, delta_x=0.25, delta_t=0.001, gamma=1.0):
     """Generate response for Cahn-Hilliard.
 
     Args:
@@ -160,7 +160,7 @@ def solve(x_data, n_steps=1, delta_x=0.25, delta_t=0.001, gamma=1.0):
 
     >>> import dask.array as da
     >>> x_data = 2 * da.random.random((1, 6, 6), chunks=(1, 6, 6)) - 1
-    >>> y_data = solve(x_data)
+    >>> y_data = solve_cahn_hilliard(x_data)
     >>> y_data.chunks
     ((1,), (6,), (6,))
 

--- a/pymks/fmks/data/checkerboard.py
+++ b/pymks/fmks/data/checkerboard.py
@@ -22,7 +22,7 @@ def _checkerboard(size, square_shape):
     return pipe(size, indices, lambda x: x // square_shape, lambda x: x.sum(axis=0) % 2)
 
 
-def generate(size, square_shape=(1,)):
+def generate_checkerboard(size, square_shape=(1,)):
     """Generate a 2-phase checkerboard microstructure
 
     Args:
@@ -32,17 +32,17 @@ def generate(size, square_shape=(1,)):
     Returns:
       a microstructure of shape "(1,) + shape"
 
-    >>> print(generate((4,)).compute())
+    >>> print(generate_checkerboard((4,)).compute())
     [[0 1 0 1]]
-    >>> print(generate((3, 3)).compute())
+    >>> print(generate_checkerboard((3, 3)).compute())
     [[[0 1 0]
       [1 0 1]
       [0 1 0]]]
-    >>> print(generate((3, 3), (2,)).compute())
+    >>> print(generate_checkerboard((3, 3), (2,)).compute())
     [[[0 0 1]
       [0 0 1]
       [1 1 0]]]
-    >>> print(generate((5, 8), (2, 3)).compute())
+    >>> print(generate_checkerboard((5, 8), (2, 3)).compute())
     [[[0 0 0 1 1 1 0 0]
       [0 0 0 1 1 1 0 0]
       [1 1 1 0 0 0 1 1]

--- a/pymks/fmks/data/delta.py
+++ b/pymks/fmks/data/delta.py
@@ -24,7 +24,7 @@ def _npgenerate(n_phases, shape):
 
 
 @curry
-def generate(n_phases, shape, chunks=()):
+def generate_delta(n_phases, shape, chunks=()):
     """Generate a delta microstructure
 
     Args:
@@ -35,7 +35,7 @@ def generate(n_phases, shape, chunks=()):
     Returns:
       a dask array of delta microstructures
 
-    >>> a = generate(5, (3, 4), chunks=(5,))
+    >>> a = generate_delta(5, (3, 4), chunks=(5,))
     >>> a.shape
     (20, 3, 4)
     >>> a.chunks

--- a/pymks/fmks/data/elastic_fe.py
+++ b/pymks/fmks/data/elastic_fe.py
@@ -12,7 +12,7 @@ n_x, n_y, n_z).
 >>> X = np.zeros((1, 3, 3), dtype=int)
 >>> X[0, :, 1] = 1
 
->>> strain = solve(
+>>> strain = solve_fe(
 ...     X,
 ...     elastic_modulus=(1.0, 10.0),
 ...     poissons_ratio=(0., 0.),
@@ -43,7 +43,7 @@ left/right periodic offset and the top/bottom periodicity.
 ...                [1, 0, 0, 1]]])
 >>> n_samples, N, N = X.shape
 >>> macro_strain = 0.1
->>> displacement = solve(
+>>> displacement = solve_fe(
 ...     X,
 ...     elastic_modulus=(10.0, 1.0),
 ...     poissons_ratio=(0.3, 0.3),
@@ -80,7 +80,7 @@ The module also works with Dask arrays,
 >>> print(X.shape)
 (2, 4, 4)
 >>> x_data = da.from_array(X, chunks=(1, 4, 4))
->>> out = solve(x_data,
+>>> out = solve_fe(x_data,
 ...             elastic_modulus=(10.0, 1.0),
 ...             poissons_ratio=(0.3, 0.3),
 ...             macro_strain=macro_strain)['displacement']
@@ -145,7 +145,7 @@ warnings.simplefilter("ignore", category=FutureWarning)
 
 
 @curry
-def solve(x_data, elastic_modulus, poissons_ratio, macro_strain=1.0, delta_x=1.0):
+def solve_fe(x_data, elastic_modulus, poissons_ratio, macro_strain=1.0, delta_x=1.0):
     """Solve the elasticity problem
 
     Args:

--- a/pymks/fmks/data/multiphase.py
+++ b/pymks/fmks/data/multiphase.py
@@ -112,7 +112,9 @@ def np_generate(grain_size, volume_fraction, percent_variance, x_blur):
 
 
 @curry
-def generate(shape, grain_size, volume_fraction, chunks=-1, percent_variance=0.0):
+def generate_multiphase(
+    shape, grain_size, volume_fraction, chunks=-1, percent_variance=0.0
+):
     """Constructs microstructures for an arbitrary number of phases
     given the size of the domain, and relative grain size.
 
@@ -134,7 +136,11 @@ def generate(shape, grain_size, volume_fraction, chunks=-1, percent_variance=0.0
     ...                    [0, 1, 0],
     ...                    [1, 1, 1]]])
     >>> da.random.seed(10)
-    >>> x = generate(shape=(1, 3, 3), grain_size=(1, 1), volume_fraction=(0.5, 0.5))
+    >>> x = generate_multiphase(
+    ...     shape=(1, 3, 3),
+    ...     grain_size=(1, 1),
+    ...     volume_fraction=(0.5, 0.5)
+    ... )
     >>> print(x.shape)
     (1, 3, 3)
     >>> print(x.chunks)

--- a/pymks/fmks/tests/test_fe.py
+++ b/pymks/fmks/tests/test_fe.py
@@ -4,7 +4,7 @@
 import pytest
 import numpy as np
 from toolz.curried import pipe, first, get
-from pymks.fmks.data.elastic_fe import solve
+from pymks.fmks.data.elastic_fe import solve_fe
 
 
 def test_3d():
@@ -19,7 +19,7 @@ def test_3d():
         5,
         lambda x: np.zeros((1, x, x, x), dtype=int),
         setone,
-        solve(elastic_modulus=(1.0, 10.0), poissons_ratio=(0.0, 0.0)),
+        solve_fe(elastic_modulus=(1.0, 10.0), poissons_ratio=(0.0, 0.0)),
         lambda x: np.allclose(
             [np.mean(x["strain"][0, ..., i]) for i in range(6)],
             [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
@@ -36,7 +36,7 @@ def test_3d_bcs():
         return pipe(
             size,
             lambda x: np.random.randint(2, size=(1, x, x, x)),
-            solve(
+            solve_fe(
                 elastic_modulus=(10.0, 1.0),
                 poissons_ratio=(0.3, 0.3),
                 macro_strain=macro_strain,
@@ -58,7 +58,7 @@ def test_issue106():
     """
 
     def test(x_data):
-        solve(x_data, elastic_modulus=(1, 2, 3), poissons_ratio=(0.3, 0.3, 0.3))
+        solve_fe(x_data, elastic_modulus=(1, 2, 3), poissons_ratio=(0.3, 0.3, 0.3))
 
     size = 5
     test(np.zeros((1, size, size, size), dtype=int))

--- a/pymks/fmks/tests/test_homogenization_fmks.py
+++ b/pymks/fmks/tests/test_homogenization_fmks.py
@@ -8,7 +8,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.decomposition import PCA
 from sklearn.linear_model import LogisticRegression
 from pymks.fmks.correlations import FlattenTransformer, TwoPointCorrelation
-from pymks.fmks.data.cahn_hilliard import solve
+from pymks.fmks.data.cahn_hilliard import solve_cahn_hilliard
 from pymks.fmks.bases.legendre import LegendreTransformer
 
 
@@ -35,14 +35,14 @@ def test_classification():
     )
     da.random.seed(3)
     x0_phase = 2 * da.random.random((50, 21, 21), chunks=(50, 21, 21)) - 1
-    x1_phase = solve(x0_phase)
+    x1_phase = solve_cahn_hilliard(x0_phase)
     y0_class = np.zeros(x0_phase.shape[0])
     y1_class = np.ones(x1_phase.shape[0])
     x_combined = np.concatenate((x0_phase, x1_phase))
     y_combined = np.concatenate((y0_class, y1_class))
     homogenization_pipeline.fit(x_combined, y_combined)
     x0_test = 2 * da.random.random((3, 21, 21), chunks=(3, 21, 21)) - 1
-    x1_test = solve(x0_test)
+    x1_test = solve_cahn_hilliard(x0_test)
     y1_test = homogenization_pipeline.predict(x1_test)
     y0_test = homogenization_pipeline.predict(x0_test)
     assert np.allclose(y0_test, [0, 0, 0])

--- a/pymks/fmks/tests/test_localization.py
+++ b/pymks/fmks/tests/test_localization.py
@@ -8,8 +8,8 @@ from pymks.fmks.bases.primitive import discretize, redundancy
 from pymks.fmks.localization import fit
 from pymks.fmks.bases.primitive import PrimitiveTransformer
 from pymks.fmks.localization import LocalizationRegressor
-from pymks.fmks.data.delta import generate
-from pymks.fmks.data.elastic_fe import solve
+from pymks.fmks.data.delta import generate_delta
+from pymks.fmks.data.elastic_fe import solve_fe
 
 
 def _get_x():
@@ -34,9 +34,9 @@ def test_setting_kernel():
     """Test resetting the coeffs after coeff resize.
     """
 
-    x_data = generate(n_phases=2, shape=(21, 21)).persist()
+    x_data = generate_delta(n_phases=2, shape=(21, 21)).persist()
 
-    y_data = solve(
+    y_data = solve_fe(
         x_data, elastic_modulus=(100, 130), poissons_ratio=(0.3, 0.3), macro_strain=0.01
     )["strain"][..., 0].persist()
 

--- a/pymks/fmks/tests/test_multiphase.py
+++ b/pymks/fmks/tests/test_multiphase.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import dask.array as da
 
-from pymks.fmks.data.multiphase import generate, np_generate
+from pymks.fmks.data.multiphase import generate_multiphase, np_generate
 from pymks.datasets.microstructure_generator import MicrostructureGenerator
 
 
@@ -16,7 +16,7 @@ def test_chunking():
 
     """
     da.random.seed(10)
-    data = generate(
+    data = generate_multiphase(
         shape=(5, 11, 11), grain_size=(3, 4), volume_fraction=(0.5, 0.5), chunks=2
     )
     assert data.shape == (5, 11, 11)
@@ -27,7 +27,9 @@ def test_2d():
     """Regression test for microstructure phases
     """
     da.random.seed(10)
-    data = generate(shape=(1, 4, 4), grain_size=(4, 4), volume_fraction=(0.5, 0.5))
+    data = generate_multiphase(
+        shape=(1, 4, 4), grain_size=(4, 4), volume_fraction=(0.5, 0.5)
+    )
     assert np.allclose(data, [[[0, 0, 0, 0], [1, 0, 1, 1], [1, 1, 0, 1], [1, 0, 0, 0]]])
 
 
@@ -35,7 +37,9 @@ def test_1d():
     """Test that 1D works
     """
     da.random.seed(10)
-    data = generate(shape=(1, 10), grain_size=(4,), volume_fraction=(0.5, 0.5))
+    data = generate_multiphase(
+        shape=(1, 10), grain_size=(4,), volume_fraction=(0.5, 0.5)
+    )
     assert np.allclose(data, [0, 0, 0, 0, 1, 0, 1, 1, 1, 1])
 
 
@@ -45,7 +49,9 @@ def test_grain_size():
     """
     with pytest.raises(RuntimeError) as excinfo:
         da.random.seed(10)
-        generate(shape=(1, 10, 10), grain_size=(4,), volume_fraction=(0.5, 0.5))
+        generate_multiphase(
+            shape=(1, 10, 10), grain_size=(4,), volume_fraction=(0.5, 0.5)
+        )
     assert str(excinfo.value) == "`shape` should be of length `len(grain_size) + 1`"
 
 
@@ -54,7 +60,9 @@ def test_volume_fraction():
     """
     with pytest.raises(RuntimeError) as excinfo:
         da.random.seed(10)
-        generate(shape=(1, 10), grain_size=(2,), volume_fraction=(0.4, 0.4, 0.4))
+        generate_multiphase(
+            shape=(1, 10), grain_size=(2,), volume_fraction=(0.4, 0.4, 0.4)
+        )
     assert str(excinfo.value) == "The terms in the volume fraction list should sum to 1"
 
 
@@ -66,7 +74,7 @@ def test_3d():
 
     """
     da.random.seed(10)
-    data = generate(
+    data = generate_multiphase(
         shape=(5, 5, 5, 5),
         grain_size=(1, 5, 1),
         volume_fraction=(0.3, 0.3, 0.4),


### PR DESCRIPTION
Use unique names for generate and solve functions in fmks/data. This is so that the documentation corresponds with the names of the functions in the API. Also easier to find the documented functions in the code.