### PR TITLE
Make pymks pip installable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 # Python CircleCI 2.0 configuration file
 version: 2.1
 jobs:
-  build:
+  conda_develop:
     docker:
       - image: continuumio/miniconda3
 
-    working_directory: ~/repo
+    working_directory: ~/repo-conda-develop
 
     steps:
       # Step 1: obtain repo from GitHub
@@ -45,3 +45,37 @@ jobs:
             py.test notebooks/multiphase.ipynb
             py.test notebooks/checkerboard.ipynb
             py.test notebooks/fiber.ipynb
+
+
+  pip_install:
+    docker:
+      - image: continuumio/miniconda3
+
+    working_directory: ~/repo-pip-install
+
+    steps:
+
+      - checkout
+
+      - run:
+          name: Setup
+          command: |
+            conda create -n pip-install python=3
+            source activate pip-install
+            pip install .
+
+      - run:
+          name: Test
+          no_output_timeout: 30m
+          command: |
+            set -e
+            source activate pip-install
+            python -c "import pymks; pymks.test()"
+
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - conda_develop
+      - pip_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
   - nix-shell --pure --command "echo 'run nix-shell'"
 script:
   - nix-shell --pure --command "export PYMKS_USE_FFTW=$PYMKS_USE_FFTW; py.test --cov-fail-under=100"
-  - nix-shell --pure --command "pylint --rcfile=.pylintrc pymks/fmks pymks/fmks/tests"
-  - nix-shell --pure --command "flake8 pymks/fmks pymks/fmks/tests"
-  - nix-shell --pure --command "black --check pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "pylint --rcfile=.pylintrc setup.py pymks/__init__.py pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "flake8 setup.py pymks/__init__.py pymks/fmks pymks/fmks/tests"
+  - nix-shell --pure --command "black --check setup.py pymks/__init__.py pymks/fmks pymks/fmks/tests"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Nix](https://nixos.org/nix/manual/#chap-quick-start), run
 
 to drop into a shell with PyMKS and all its requirements available.
 
+#### Pip
+
+Install a minimal version of PyMKS with
+
+    $ pip install pymks
+
+This is enough to run the tests, but not the examples. Some optional
+packages are not available via Pip.
+
 ## Testing
 
 To test a PyMKS installation use

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -1,11 +1,19 @@
+"""PyMKS - the materials knowledge system in Python
+
+See the documenation for details at https://pymks.org
+"""
+
 try:
-    import pyfftw
-    ## ensure that pyfftw is always imported before numpy to avoid
-    ## https://github.com/materialsinnovation/pymks/issues/304
-except:
+    import pyfftw  # noqa: F401
+
+    # ensure that pyfftw is always imported before numpy to avoid
+    # https://github.com/materialsinnovation/pymks/issues/304
+except ImportError:
     pass
 
 import os
+
+
 from .fmks.data.cahn_hilliard import solve as solve_cahn_hilliard
 from .fmks.plot import plot_microstructures
 from .fmks.bases.primitive import PrimitiveTransformer
@@ -14,7 +22,20 @@ from .fmks.localization import LocalizationRegressor
 from .fmks.localization import ReshapeTransformer
 from .fmks.localization import coeff_to_real
 from .fmks.data.delta import generate as generate_delta
-from .fmks.data.elastic_fe import solve as solve_fe
+
+try:
+    import sfepy  # noqa: F401
+except ImportError:
+
+    def solve_fe(*_, **__):
+        """Dummy funcion when sfepy unavailable
+        """
+        # pylint: disable=redefined-outer-name, import-outside-toplevel, unused-import
+        import sfepy  # noqa: F401, F811
+
+
+else:
+    from .fmks.data.elastic_fe import solve as solve_fe
 from .fmks.data.multiphase import generate as generate_multiphase
 from .fmks.correlations import FlattenTransformer
 from .fmks.correlations import TwoPointCorrelation
@@ -25,6 +46,7 @@ from .bases.primitive import PrimitiveBasis
 from .bases.legendre import LegendreBasis
 from .mks_structure_analysis import MKSStructureAnalysis
 from .mks_homogenization_model import MKSHomogenizationModel
+
 MKSRegressionModel = MKSLocalizationModel
 DiscreteIndicatorBasis = PrimitiveBasis
 ContinuousIndicatorBasis = PrimitiveBasis
@@ -34,9 +56,10 @@ def test():
     r"""
     Run all the doctests available.
     """
-    import pytest
-    path = os.path.split(__file__)[0]
-    pytest.main(args=[path, '--doctest-modules', '-r s'])
+    import pytest  # pylint: disable=import-outside-toplevel
+
+    path = os.path.join(os.path.split(__file__)[0], "fmks")
+    pytest.main(args=[path, "--doctest-modules", "-r s"])
 
 
 def get_version():
@@ -45,35 +68,40 @@ def get_version():
     Returns:
       the package version number
     """
+    # pylint: disable=import-outside-toplevel
     from pkg_resources import get_distribution, DistributionNotFound
 
     try:
-        version = get_distribution(__name__.split('.')[0]).version # pylint: disable=no-member
-    except DistributionNotFound: # pragma: no cover
+        version = get_distribution(
+            __name__.split(".")[0]
+        ).version  # pylint: disable=no-member
+    except DistributionNotFound:  # pragma: no cover
         version = "unknown, try running `python setup.py egg_info`"
 
     return version
 
+
 __version__ = get_version()
 
-__all__ = ['__version__',
-           'test',
-           'solve_cahn_hilliard',
-           'plot_microstructures',
-           'PrimitiveTransformer',
-           'LocalizationRegressor',
-           'ReshapeTransformer',
-           'coeff_to_real'
-           'MKSLocalizationModel',
-           'PrimitiveBasis',
-           'LegendreBasis',
-           'MKSHomogenizationModel',
-           'MKSStructureAnalysis',
-           'generate_delta',
-           'LegendreTransformer',
-           'solve_fe',
-           'generate_multiphase',
-           'FlattenTransformer',
-           'TwoPointCorrelation',
-           'generate_checkerboard'
+__all__ = [
+    "__version__",
+    "test",
+    "solve_cahn_hilliard",
+    "plot_microstructures",
+    "PrimitiveTransformer",
+    "LocalizationRegressor",
+    "ReshapeTransformer",
+    "coeff_to_real",
+    "MKSLocalizationModel",
+    "PrimitiveBasis",
+    "LegendreBasis",
+    "MKSHomogenizationModel",
+    "MKSStructureAnalysis",
+    "generate_delta",
+    "LegendreTransformer",
+    "solve_fe",
+    "generate_multiphase",
+    "FlattenTransformer",
+    "TwoPointCorrelation",
+    "generate_checkerboard",
 ]

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -52,6 +52,7 @@ DiscreteIndicatorBasis = PrimitiveBasis
 ContinuousIndicatorBasis = PrimitiveBasis
 # the above will be deprecatec
 
+
 def test():
     r"""
     Run all the doctests available.

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 
+"""PyMKS - the materials knowledge system in Python
+
+See the documenation for details at https://pymks.org
+"""
+
+import warnings
+import os
 import subprocess
 from setuptools import setup, find_packages
-import os
 
 
 def make_version(package_name):
@@ -11,6 +17,7 @@ def make_version(package_name):
     Returns:
       version number of the form "3.1.1.dev127+g413ed61".
     """
+
     def _minimal_ext_cmd(cmd):
         """Run a command in a subprocess.
 
@@ -22,28 +29,22 @@ def make_version(package_name):
         """
         # construct minimal environment
         env = {}
-        for k in ['SYSTEMROOT', 'PATH']:
+        for k in ["SYSTEMROOT", "PATH"]:
             value = os.environ.get(k)
             if value is not None:
                 env[k] = value
         # LANGUAGE is used on win32
-        env['LANGUAGE'] = 'C'
-        env['LANG'] = 'C'
-        env['LC_ALL'] = 'C'
-        out = subprocess.Popen(cmd,
-                               stdout=subprocess.PIPE,
-                               env=env).communicate()[0]
+        env["LANGUAGE"] = "C"
+        env["LANG"] = "C"
+        env["LC_ALL"] = "C"
+        out = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
         return out
 
-    version = 'unknown'
+    version = "unknown"
 
-    if os.path.exists('.git'):
+    if os.path.exists(".git"):
         try:
-            out = _minimal_ext_cmd(['git',
-                                    'describe',
-                                    '--tags',
-                                    '--match',
-                                    'v*'])
+            out = _minimal_ext_cmd(["git", "describe", "--tags", "--match", "v*"])
             # ticket:475 - fix for bytecode received in Py3k
             # http://jeetworks.org/node/67
             outdecode = out.decode("utf-8")
@@ -57,13 +58,16 @@ def make_version(package_name):
             else:
                 version = version[0][1:]
         except OSError:
-            import warnings
             warnings.warn("Could not run ``git describe``")
-    elif os.path.exists('pymks.egg-info'):
+    elif os.path.exists("pymks.egg-info"):
+        # pylint: disable=import-outside-toplevel
         from pkg_resources import get_distribution, DistributionNotFound
+
         try:
-            version = get_distribution(package_name).version # pylint: disable=no-member
-        except DistributionNotFound: # pragma: no cover
+            version = get_distribution(
+                package_name
+            ).version  # pylint: disable=no-member
+        except DistributionNotFound:  # pragma: no cover
             version = "unknown, try running `python setup.py egg_info`"
 
     return version
@@ -72,13 +76,25 @@ def make_version(package_name):
 PACKAGE_NAME = "pymks"
 
 
-setup(name=PACKAGE_NAME,
-      version=make_version(PACKAGE_NAME),
-      description='Materials Knowledge Systems in Python (PyMKS)',
-      author='Daniel Wheeler',
-      author_email='daniel.wheeler2@gmail.com',
-      url='http://pymks.org',
-      packages=find_packages(),
-      package_data={'': ['tests/*.py']},
-      install_requires=[],
-      data_files=['setup.cfg'])
+setup(
+    name=PACKAGE_NAME,
+    version=make_version(PACKAGE_NAME),
+    description="Materials Knowledge Systems in Python (PyMKS)",
+    author="Daniel Wheeler",
+    author_email="daniel.wheeler2@gmail.com",
+    url="http://pymks.org",
+    packages=find_packages(),
+    package_data={"": ["tests/*.py"]},
+    install_requires=[
+        "pytest",
+        "numpy",
+        "dask",
+        "Deprecated",
+        "matplotlib",
+        "scikit-learn",
+        "pytest-cov",
+        "nbval",
+        "toolz",
+    ],
+    data_files=["setup.cfg"],
+)


### PR DESCRIPTION
Makes pymks pip installable with the mimimal set of packages for running `python -c "import pymks; pymks.test()"`.

To review this make an empth conda environment and then run

    $ pip install pymks==0.4a2

and then run the install tests.