### PR TITLE
fix: use func.curry to preserve function docstring

### DIFF
--- a/doc/API.rst
+++ b/doc/API.rst
@@ -6,7 +6,7 @@ API
 
 .. jinja::
 
-   {% set functions = ['plot_microstructures', 'generate_delta', 'generate_multiphase', 'generate_checkerboard', 'solve_cahn_hilliard', 'solve_fe', 'coeff_to_real', 'paircorr_from_twopoint'] | sort %}
+   {% set functions = ['plot_microstructures', 'generate_delta', 'generate_multiphase', 'generate_checkerboard', 'solve_cahn_hilliard', 'solve_fe', 'coeff_to_real', 'paircorr_from_twopoint', 'two_point_stats'] | sort %}
 
    {% set classes = ['PrimitiveTransformer', 'LegendreTransformer', 'TwoPointCorrelation', 'FlattenTransformer', 'LocalizationRegressor', 'ReshapeTransformer'] | sort %}
 

--- a/pymks/__init__.py
+++ b/pymks/__init__.py
@@ -26,6 +26,7 @@ from .fmks.correlations import FlattenTransformer
 from .fmks.correlations import TwoPointCorrelation
 from .fmks.data.checkerboard import generate_checkerboard
 from .fmks.pair_correlations import paircorr_from_twopoint
+from .fmks.correlations import two_point_stats
 
 try:
     import sfepy  # noqa: F401
@@ -107,4 +108,5 @@ __all__ = [
     "TwoPointCorrelation",
     "generate_checkerboard",
     "paircorr_from_twopoint",
+    "two_point_stats",
 ]

--- a/pymks/fmks/data/multiphase.py
+++ b/pymks/fmks/data/multiphase.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import dask.array as da
-from toolz.curried import curry, pipe
+from toolz.curried import pipe
 from toolz.curried import map as fmap
 from scipy.ndimage.fourier import fourier_gaussian
 from ..func import (
@@ -14,6 +14,7 @@ from ..func import (
     zero_pad,
     sequence,
     map_blocks,
+    curry,
 )
 
 


### PR DESCRIPTION
Use func.curry instead of toolz's curry to preserve the
docstrings. Additionally,

 - Add two_point_stats to the API
 - Improve the documentation of two_point_stats