### PR TITLE
build(nix): fix development environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   pname = "pymks";
   version = "0.4.2";
 
-  src = builtins.filterSource (path: type: type != "directory" || baseNameOf path != ".git") ./.;
+  src = lib.cleanSource ./.;
 
   propagatedBuildInputs = [
     sfepy

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ in
 
     propagatedBuildInputs = old.propagatedBuildInputs;
 
-    nativeBuildInputs = propagatedBuildInputs ++ extra ++ [ pymks ];
+    nativeBuildInputs = propagatedBuildInputs ++ extra;
 
     postShellHook = ''
       export OMPI_MCA_plm_rsh_agent=${pkgs.openssh}/bin/ssh
@@ -31,7 +31,7 @@ in
       SOURCE_DATE_EPOCH=$(date +%s)
       export PYTHONUSERBASE=$PWD/.local
       export USER_SITE=`python -c "import site; print(site.USER_SITE)"`
-      export PYTHONPATH=$PYTHONPATH:$USER_SITE
+      export PYTHONPATH=$PYTHONPATH:$USER_SITE:$(pwd)
       export PATH=$PATH:$PYTHONUSERBASE/bin
 
       jupyter nbextension install --py widgetsnbextension --user > /dev/null 2>&1


### PR DESCRIPTION
The development environment was broken when using nix-shell. The
version of pymks used was from the nix store not from the local
working repository unless running python from withing the local base
working repository. This showed up when running a notebook. The
imported pymks was the nix store installed version at the time of
running nix-shell and didn't include any edits to the working
copy. Using filterSource to filter the source tree was doing something
so that buildPythonPackage didn't recognize that the pymks was a
development environment. cleanSource seems to avoid that problem.